### PR TITLE
[#20] Setup project localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ Carthage/Build
 */fastlane/test_output
 
 .env
+/R.generated.swift

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 excluded:
   - NimbleMediumTests/Sources/Mocks/Sourcery/AutoMockable.generated.swift
   - Pods
+  - R.generated.swift
 
 opt_in_rules:
   - anyobject_protocol

--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -8,11 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		2D467C3D26BCD58D008F11E1 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D467C3C26BCD58D008F11E1 /* HomeView.swift */; };
+		2D64E92026C11B48008C80B0 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2D64E92226C11B48008C80B0 /* Localizable.strings */; };
 		2DB2674E26BBEC4300FF05BB /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB2674D26BBEC4300FF05BB /* App.swift */; };
 		2DB2675226BBEC4400FF05BB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DB2675126BBEC4400FF05BB /* Assets.xcassets */; };
 		2DB2675526BBEC4400FF05BB /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DB2675426BBEC4400FF05BB /* Preview Assets.xcassets */; };
 		2DB2676026BBEC4500FF05BB /* NimbleMediumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB2675F26BBEC4500FF05BB /* NimbleMediumTests.swift */; };
 		2DB2676B26BBEC4500FF05BB /* NimbleMediumUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB2676A26BBEC4500FF05BB /* NimbleMediumUITests.swift */; };
+		2DB726B926C1188500C16716 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB726B826C1188500C16716 /* R.generated.swift */; };
 		50CD01A577A1A5CB6812AF2E /* Pods_NimbleMedium_NimbleMediumUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 901D8FC4774E2CF838738DEF /* Pods_NimbleMedium_NimbleMediumUITests.framework */; };
 		7DB2A8DC1F8863DD01F7D438 /* Pods_NimbleMedium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8319E63645C8E624FA94506E /* Pods_NimbleMedium.framework */; };
 		B56F45E43AAEF74BD71B4158 /* Pods_NimbleMediumTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDBC77E99D264744421CC502 /* Pods_NimbleMediumTests.framework */; };
@@ -39,6 +41,7 @@
 		1FB4ECE354F839DF02D6976B /* Pods-NimbleMedium.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.staging.xcconfig"; sourceTree = "<group>"; };
 		21851292A064EB97674233A2 /* Pods-NimbleMediumTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.staging.xcconfig"; sourceTree = "<group>"; };
 		2D467C3C26BCD58D008F11E1 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		2D64E92126C11B48008C80B0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2DB2674A26BBEC4300FF05BB /* Nimble Medium.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Nimble Medium.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2DB2674D26BBEC4300FF05BB /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		2DB2675126BBEC4400FF05BB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -50,6 +53,7 @@
 		2DB2676626BBEC4500FF05BB /* NimbleMediumUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NimbleMediumUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2DB2676A26BBEC4500FF05BB /* NimbleMediumUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbleMediumUITests.swift; sourceTree = "<group>"; };
 		2DB2676C26BBEC4500FF05BB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2DB726B826C1188500C16716 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = SOURCE_ROOT; };
 		664F4E0BC9D9E468E0506C22 /* Pods-NimbleMediumTests.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.production.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.production.xcconfig"; sourceTree = "<group>"; };
 		6E41E63B326C526EFD5BA685 /* Pods-NimbleMedium.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.production.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.production.xcconfig"; sourceTree = "<group>"; };
 		8319E63645C8E624FA94506E /* Pods_NimbleMedium.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NimbleMedium.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -144,6 +148,7 @@
 				2DB2677E26BBF13400FF05BB /* Modules */,
 				2DB2674D26BBEC4300FF05BB /* App.swift */,
 				2DB2675626BBEC4400FF05BB /* Info.plist */,
+				2DB726B826C1188500C16716 /* R.generated.swift */,
 				2DB2675326BBEC4400FF05BB /* Preview Content */,
 			);
 			path = NimbleMedium;
@@ -178,6 +183,7 @@
 		2DB2677C26BBF12500FF05BB /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				2D64E92226C11B48008C80B0 /* Localizable.strings */,
 				2DB2675126BBEC4400FF05BB /* Assets.xcassets */,
 			);
 			path = Resources;
@@ -234,11 +240,12 @@
 			buildConfigurationList = 2DB2676F26BBEC4500FF05BB /* Build configuration list for PBXNativeTarget "NimbleMedium" */;
 			buildPhases = (
 				E04254B9DADFA4DADB8744F5 /* [CP] Check Pods Manifest.lock */,
+				2DB726B726C117D500C16716 /* R.swift */,
 				2DB2674626BBEC4300FF05BB /* Sources */,
 				2DB2674726BBEC4300FF05BB /* Frameworks */,
 				2DB2674826BBEC4300FF05BB /* Resources */,
-				2D467C4626BCDAA9008F11E1 /* ShellScript */,
 				76B7F7643F3D9F1792479914 /* [CP] Embed Pods Frameworks */,
+				2D467C4626BCDAA9008F11E1 /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -341,6 +348,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2DB2675526BBEC4400FF05BB /* Preview Assets.xcassets in Resources */,
+				2D64E92026C11B48008C80B0 /* Localizable.strings in Resources */,
 				2DB2675226BBEC4400FF05BB /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -384,7 +392,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2D467C4626BCDAA9008F11E1 /* ShellScript */ = {
+		2D467C4626BCDAA9008F11E1 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -393,6 +401,7 @@
 			);
 			inputPaths = (
 			);
+			name = SwiftLint;
 			outputFileListPaths = (
 			);
 			outputPaths = (
@@ -400,6 +409,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\"\n";
+		};
+		2DB726B726C117D500C16716 /* R.swift */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$TEMP_DIR/rswift-lastrun",
+			);
+			name = R.swift;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				$SRCROOT/R.generated.swift,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$PODS_ROOT/R.swift/rswift\" generate \"$SRCROOT/R.generated.swift\"\n";
 		};
 		70D4ED73D3FABDF90D65AB83 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -505,6 +534,7 @@
 			files = (
 				2D467C3D26BCD58D008F11E1 /* HomeView.swift in Sources */,
 				2DB2674E26BBEC4300FF05BB /* App.swift in Sources */,
+				2DB726B926C1188500C16716 /* R.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -538,6 +568,17 @@
 			targetProxy = 2DB2676726BBEC4500FF05BB /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		2D64E92226C11B48008C80B0 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				2D64E92126C11B48008C80B0 /* en */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		2DB2676E26BBEC4500FF05BB /* Production */ = {

--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		2DB2676026BBEC4500FF05BB /* NimbleMediumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB2675F26BBEC4500FF05BB /* NimbleMediumTests.swift */; };
 		2DB2676B26BBEC4500FF05BB /* NimbleMediumUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB2676A26BBEC4500FF05BB /* NimbleMediumUITests.swift */; };
 		2DB726B926C1188500C16716 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB726B826C1188500C16716 /* R.generated.swift */; };
+		2DE3B9B526C1339200272775 /* Typealias.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3B9B426C1339200272775 /* Typealias.swift */; };
 		50CD01A577A1A5CB6812AF2E /* Pods_NimbleMedium_NimbleMediumUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 901D8FC4774E2CF838738DEF /* Pods_NimbleMedium_NimbleMediumUITests.framework */; };
 		7DB2A8DC1F8863DD01F7D438 /* Pods_NimbleMedium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8319E63645C8E624FA94506E /* Pods_NimbleMedium.framework */; };
 		B56F45E43AAEF74BD71B4158 /* Pods_NimbleMediumTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDBC77E99D264744421CC502 /* Pods_NimbleMediumTests.framework */; };
@@ -54,6 +55,7 @@
 		2DB2676A26BBEC4500FF05BB /* NimbleMediumUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbleMediumUITests.swift; sourceTree = "<group>"; };
 		2DB2676C26BBEC4500FF05BB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2DB726B826C1188500C16716 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = SOURCE_ROOT; };
+		2DE3B9B426C1339200272775 /* Typealias.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typealias.swift; sourceTree = "<group>"; };
 		664F4E0BC9D9E468E0506C22 /* Pods-NimbleMediumTests.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.production.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.production.xcconfig"; sourceTree = "<group>"; };
 		6E41E63B326C526EFD5BA685 /* Pods-NimbleMedium.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.production.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.production.xcconfig"; sourceTree = "<group>"; };
 		8319E63645C8E624FA94506E /* Pods_NimbleMedium.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NimbleMedium.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -146,6 +148,7 @@
 				2D467C3F26BCD68C008F11E1 /* Services */,
 				2DB2678026BBF14C00FF05BB /* Repositories */,
 				2DB2677E26BBF13400FF05BB /* Modules */,
+				2DE3B9B226C1336300272775 /* Supports */,
 				2DB2674D26BBEC4300FF05BB /* App.swift */,
 				2DB2675626BBEC4400FF05BB /* Info.plist */,
 				2DB726B826C1188500C16716 /* R.generated.swift */,
@@ -217,6 +220,22 @@
 			children = (
 			);
 			path = Repositories;
+			sourceTree = "<group>";
+		};
+		2DE3B9B226C1336300272775 /* Supports */ = {
+			isa = PBXGroup;
+			children = (
+				2DE3B9B326C1337800272775 /* Helpers */,
+			);
+			path = Supports;
+			sourceTree = "<group>";
+		};
+		2DE3B9B326C1337800272775 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				2DE3B9B426C1339200272775 /* Typealias.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		6BCBF057E18C8FD57CD13FD1 /* Pods */ = {
@@ -534,6 +553,7 @@
 			files = (
 				2D467C3D26BCD58D008F11E1 /* HomeView.swift in Sources */,
 				2DB2674E26BBEC4300FF05BB /* App.swift in Sources */,
+				2DE3B9B526C1339200272775 /* Typealias.swift in Sources */,
 				2DB726B926C1188500C16716 /* R.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/NimbleMedium/Modules/Home/HomeView.swift
+++ b/NimbleMedium/Modules/Home/HomeView.swift
@@ -9,13 +9,8 @@ import SwiftUI
 
 struct HomeView: View {
     var body: some View {
-        #if PRODUCTION
-        Text("Hello, production build")
+        Text(R.string.localizable.homeTitle())
             .padding()
-        #elseif STAGING
-        Text("Hello, staging build")
-            .padding()
-        #endif
     }
 }
 

--- a/NimbleMedium/Modules/Home/HomeView.swift
+++ b/NimbleMedium/Modules/Home/HomeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct HomeView: View {
     var body: some View {
-        Text(R.string.localizable.homeTitle())
+        Text(Localizable.homeTitle())
             .padding()
     }
 }

--- a/NimbleMedium/Resources/en.lproj/Localizable.strings
+++ b/NimbleMedium/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+/* 
+  Localizable.strings
+  NimbleMedium
+
+  Created by Mark G on 09/08/2021.
+  
+*/
+
+"home.title" = "Feed";

--- a/NimbleMedium/Supports/Helpers/Typealias.swift
+++ b/NimbleMedium/Supports/Helpers/Typealias.swift
@@ -1,0 +1,9 @@
+//  swiftlint:disable:this file_name
+//
+//  Typealias.swift
+//  NimbleMedium
+//
+//  Created by Mark G on 09/08/2021.
+//
+
+typealias Localizable = R.string.localizable

--- a/Podfile
+++ b/Podfile
@@ -14,6 +14,7 @@ target 'NimbleMedium' do
   pod 'RxGesture'
   pod 'SwiftLint'
   pod 'AlamofireNetworkActivityLogger'
+  pod 'R.swift'
   
   target 'NimbleMediumTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,6 +5,9 @@ PODS:
   - Differentiator (5.0.0)
   - Nimble (9.2.0)
   - Quick (4.0.0)
+  - R.swift (5.4.0):
+    - R.swift.Library (~> 5.3.0)
+  - R.swift.Library (5.3.0)
   - RxAlamofire (6.1.1):
     - RxAlamofire/Core (= 6.1.1)
   - RxAlamofire/Core (6.1.1):
@@ -43,6 +46,7 @@ DEPENDENCIES:
   - AlamofireNetworkActivityLogger
   - Nimble
   - Quick
+  - R.swift
   - RxAlamofire
   - RxCocoa
   - RxDataSources
@@ -60,6 +64,8 @@ SPEC REPOS:
     - Differentiator
     - Nimble
     - Quick
+    - R.swift
+    - R.swift.Library
     - RxAlamofire
     - RxBlocking
     - RxCocoa
@@ -78,6 +84,8 @@ SPEC CHECKSUMS:
   Differentiator: e8497ceab83c1b10ca233716d547b9af21b9344d
   Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
+  R.swift: c533450b0f7dc494e0993f5f1a1db925d84c3006
+  R.swift.Library: 0fc583cb55a99e28901299cc451614cad1161962
   RxAlamofire: beb75a1c452d0de225651db4903f5d29d034a620
   RxBlocking: 0b29f7d2079109a8de49c411381bed7c33ef1eeb
   RxCocoa: 4baf94bb35f2c0ab31bc0cb9f1900155f646ba42
@@ -90,6 +98,6 @@ SPEC CHECKSUMS:
   Sourcery: 43d8addc35ca31c2ab331cfd34b02421fa53bb7f
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: 2210b22fb9e1e2221a9f02790e5dd6d8ac186fb5
+PODFILE CHECKSUM: 07377c00361088abf2af811d3c9894bc200b607a
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
Resolved #20 

## What happened

When starting a new project, the project localization should be setup properly for removing the usage of hardcoded texts and thus easily supporting a new language in the future.

## Insight

- Add R.swift dependency thru Cocoapod
- Add localizable file
- Ignore R.generated.swift in swiftlint & git

## Proof Of Work
Display a localized text
<img width="300" alt="Screen Shot 2021-08-09 at 16 06 09" src="https://user-images.githubusercontent.com/17875522/128683102-4cb1b13f-d835-4c04-b208-f779aac72b97.png">

