### PR TITLE
[#4] Set up CD pipeline for production releases

### DIFF
--- a/.github/workflows/deploy_testflight.yml
+++ b/.github/workflows/deploy_testflight.yml
@@ -1,0 +1,69 @@
+name: Deploy to Test Flight (production)
+
+on:
+  push:
+    branches: [ master, main ]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Run SwiftLint
+      uses: norio-nomura/action-swiftlint@3.1.0
+      with:
+        args: --strict
+
+  build:
+    name: Build
+    runs-on: macOS-latest
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.5.0
+      with:
+        access_token: ${{ github.token }}
+
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+    # Set fetch-depth (default: 1) to get whole tree
+      with:
+        fetch-depth: 0
+
+    - name: Install SSH key
+      uses: webfactory/ssh-agent@v0.4.1
+      with:
+        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+    - name: Bundle install
+      run: bundle install
+
+    - name: Cache Pods
+      uses: actions/cache@v2
+      id: cocoapodCache
+      with:
+        path: Pods
+        key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-pods-
+
+    - name: Install Pods Dependencies
+      run: bundle exec pod install
+      shell: bash
+
+    - name: Build and Test
+      run: xcodebuild -workspace NimbleMedium.xcworkspace -scheme 'NimbleMedium' -destination 'platform=iOS Simulator,name=iPhone 12' clean test && exit ${PIPESTATUS[0]}
+
+    - name: Match AppStore
+      run: bundle exec fastlane sync_appstore_signing_ci
+      env:
+        MATCH_PASSWORD: ${{ secrets.MATCH_PASS }}
+
+    - name: Build App and Distribute to AppStore
+      run: bundle exec fastlane build_and_upload_testflight
+      env:
+        APPSTORE_CONNECT_API_KEY: ${{ secrets.APPSTORE_CONNECT_API_KEY }}

--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -1587,6 +1587,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"NimbleMedium/Resources/Preview Content\"";
 				DEVELOPMENT_TEAM = 4TWS7E2EPE;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = NimbleMedium/Configurations/Plists/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
Resolved #4

## What happened

When starting a new project, the CD pipeline should be setup properly for automatically testing to validate if changes to the codebase are correct and stable for immediate autonomous deployment to a production environment.

## Insight

- Add app icon due to it's required to upload into AppStore
- Add Deploy to TestFlight github action
- Update constants for Fastlane

## Proof Of Work
TestFlight
<img width="1503" alt="Screen Shot 2021-08-25 at 09 08 49" src="https://user-images.githubusercontent.com/17875522/130714752-d5546ae8-a984-4fbd-ab86-ffd8d627e565.png">

Github Action
<img width="395" alt="Screen Shot 2021-08-30 at 14 13 29" src="https://user-images.githubusercontent.com/17875522/131300282-c5e9c17f-7048-4bac-b4ae-1729f5bbf7be.png">


