### PR TITLE
[#11] As a user, I can view the default left menu header when not logged in

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		246A8FB826D39C24009F9753 /* SideMenuHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246A8FB726D39C24009F9753 /* SideMenuHeaderView.swift */; };
 		2497356126D34F3200177A7C /* SideMenuActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2497356026D34F3200177A7C /* SideMenuActionsView.swift */; };
 		2497356326D35BBD00177A7C /* MenuOptionButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */; };
 		2D2F456026C25911002C0331 /* View+NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D2F455F26C25911002C0331 /* View+NavigationBar.swift */; };
@@ -54,6 +55,7 @@
 /* Begin PBXFileReference section */
 		1FB4ECE354F839DF02D6976B /* Pods-NimbleMedium.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.staging.xcconfig"; sourceTree = "<group>"; };
 		21851292A064EB97674233A2 /* Pods-NimbleMediumTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.staging.xcconfig"; sourceTree = "<group>"; };
+		246A8FB726D39C24009F9753 /* SideMenuHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuHeaderView.swift; sourceTree = "<group>"; };
 		2497356026D34F3200177A7C /* SideMenuActionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionsView.swift; sourceTree = "<group>"; };
 		2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionButtonStyle.swift; sourceTree = "<group>"; };
 		2D2F455F26C25911002C0331 /* View+NavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+NavigationBar.swift"; sourceTree = "<group>"; };
@@ -595,9 +597,10 @@
 		2DBE36AF26C3B32B00DA3511 /* SideMenu */ = {
 			isa = PBXGroup;
 			children = (
-				2DBE36B026C3B33700DA3511 /* SideMenuView.swift */,
-				2497356026D34F3200177A7C /* SideMenuActionsView.swift */,
 				2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */,
+				2497356026D34F3200177A7C /* SideMenuActionsView.swift */,
+				246A8FB726D39C24009F9753 /* SideMenuHeaderView.swift */,
+				2DBE36B026C3B33700DA3511 /* SideMenuView.swift */,
 			);
 			path = SideMenu;
 			sourceTree = "<group>";
@@ -937,6 +940,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2D303B3B26C28AC200EEF1C0 /* Constants+String.swift in Sources */,
+				246A8FB826D39C24009F9753 /* SideMenuHeaderView.swift in Sources */,
 				2DBE36AE26C3B0C500DA3511 /* FeedsView.swift in Sources */,
 				2DBE36B126C3B33700DA3511 /* SideMenuView.swift in Sources */,
 				2D72E47E26C2185400861239 /* Constants.swift in Sources */,

--- a/NimbleMedium/Resources/en.lproj/Localizable.strings
+++ b/NimbleMedium/Resources/en.lproj/Localizable.strings
@@ -8,4 +8,8 @@
 
 "feed.title" = "Feed";
 
+"menu.header.title" = "Nimble Medium";
+
+"menu.header.description" = "A place to share your knowledge";
+
 "menu.option.login" = "Login";

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuHeaderView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuHeaderView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct SideMenuHeaderView: View {
 
     var body: some View {
-
         ZStack(alignment: .center) {
             Color.green.edgesIgnoringSafeArea(.all)
             VStack(alignment: .center) {

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuHeaderView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuHeaderView.swift
@@ -1,0 +1,36 @@
+//
+//  SideMenuHeaderView.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 23/08/2021.
+//
+
+import SwiftUI
+
+struct SideMenuHeaderView: View {
+
+    var body: some View {
+
+        ZStack(alignment: .center) {
+            Color.green.edgesIgnoringSafeArea(.all)
+            VStack(alignment: .center) {
+                Text(Localizable.menuHeaderTitle())
+                    .foregroundColor(.white)
+                    .font(.system(size: 28, weight: .heavy, design: .default))
+                    .padding()
+                Text(Localizable.menuHeaderDescription())
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+                    .padding()
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct SideMenuHeaderView_Previews: PreviewProvider {
+    static var previews: some View {
+        SideMenuHeaderView()
+    }
+}
+#endif

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuView.swift
@@ -10,9 +10,11 @@ import SwiftUI
 struct SideMenuView: View {
     
     var body: some View {
-        VStack(alignment: .center) {
-            // TODO: Implement Menu Header UI
-            SideMenuActionsView()
+        GeometryReader { metrics in
+            VStack(alignment: .center) {
+                SideMenuHeaderView().frame(height: metrics.size.height * 0.3)
+                SideMenuActionsView()
+            }
         }
     }
 }


### PR DESCRIPTION
Resolved #11

## What happened

When user doesn't login to the app yet, the users will be able to see the left menu header with some default information about the app.

## Insight

- [x] Create a header view region with green background.
- [x] Show the application's name in white with bold text: `Nimble Medium`.
- [x] Show the application's description in white with normal text: `A place to share your knowledge`.
- [x] Set the header view height to 1/3 of the screen's height.

## Proof Of Work

https://user-images.githubusercontent.com/70877098/130425740-8b8dc396-428f-475a-b545-292cf0ba1159.mov


