### PR TITLE
[#24] As a user, I can login to the application

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -7,8 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		246A8FB826D39C24009F9753 /* SideMenuHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246A8FB726D39C24009F9753 /* SideMenuHeaderView.swift */; };
 		241B4EEA26D3B3F4000409CC /* SideMenuActionItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */; };
+		2424B22C26D4A22B00CF07B5 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2424B22B26D4A22B00CF07B5 /* LoginView.swift */; };
+		2424B22F26D4A2EF00CF07B5 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2424B22E26D4A2EF00CF07B5 /* LoginViewModel.swift */; };
+		246A8FB826D39C24009F9753 /* SideMenuHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246A8FB726D39C24009F9753 /* SideMenuHeaderView.swift */; };
 		2497356126D34F3200177A7C /* SideMenuActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2497356026D34F3200177A7C /* SideMenuActionsView.swift */; };
 		2497356326D35BBD00177A7C /* MenuOptionButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */; };
 		2D2F456026C25911002C0331 /* View+NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D2F455F26C25911002C0331 /* View+NavigationBar.swift */; };
@@ -56,8 +58,10 @@
 /* Begin PBXFileReference section */
 		1FB4ECE354F839DF02D6976B /* Pods-NimbleMedium.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.staging.xcconfig"; sourceTree = "<group>"; };
 		21851292A064EB97674233A2 /* Pods-NimbleMediumTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.staging.xcconfig"; sourceTree = "<group>"; };
-		246A8FB726D39C24009F9753 /* SideMenuHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuHeaderView.swift; sourceTree = "<group>"; };
 		241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionItemView.swift; sourceTree = "<group>"; };
+		2424B22B26D4A22B00CF07B5 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		2424B22E26D4A2EF00CF07B5 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		246A8FB726D39C24009F9753 /* SideMenuHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuHeaderView.swift; sourceTree = "<group>"; };
 		2497356026D34F3200177A7C /* SideMenuActionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionsView.swift; sourceTree = "<group>"; };
 		2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionButtonStyle.swift; sourceTree = "<group>"; };
 		2D2F455F26C25911002C0331 /* View+NavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+NavigationBar.swift"; sourceTree = "<group>"; };
@@ -131,6 +135,15 @@
 				EDBC77E99D264744421CC502 /* Pods_NimbleMediumTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		2424B22D26D4A23100CF07B5 /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				2424B22B26D4A22B00CF07B5 /* LoginView.swift */,
+				2424B22E26D4A2EF00CF07B5 /* LoginViewModel.swift */,
+			);
+			path = Login;
 			sourceTree = "<group>";
 		};
 		2D303B3C26C28AE900EEF1C0 /* Foundation */ = {
@@ -574,8 +587,9 @@
 			isa = PBXGroup;
 			children = (
 				2DBE36AC26C3B0B500DA3511 /* Feeds */,
-				2DBE36AF26C3B32B00DA3511 /* SideMenu */,
 				2D467C3E26BCD591008F11E1 /* Home */,
+				2424B22D26D4A23100CF07B5 /* Login */,
+				2DBE36AF26C3B32B00DA3511 /* SideMenu */,
 			);
 			path = Modules;
 			sourceTree = "<group>";
@@ -600,7 +614,7 @@
 			isa = PBXGroup;
 			children = (
 				2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */,
-                241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */,
+				241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */,
 				2497356026D34F3200177A7C /* SideMenuActionsView.swift */,
 				246A8FB726D39C24009F9753 /* SideMenuHeaderView.swift */,
 				2DBE36B026C3B33700DA3511 /* SideMenuView.swift */,
@@ -955,11 +969,13 @@
 				2D69824426C22DC700860A98 /* R.generated.swift in Sources */,
 				2DB04AD726C3A4AC003E65F4 /* Color+UIColor.swift in Sources */,
 				2497356126D34F3200177A7C /* SideMenuActionsView.swift in Sources */,
+				2424B22C26D4A22B00CF07B5 /* LoginView.swift in Sources */,
 				2D5485BC26CA077600FFE707 /* View+RxDriver.swift in Sources */,
 				2DB2674E26BBEC4300FF05BB /* App.swift in Sources */,
 				2D5485BE26CA0D2C00FFE707 /* PublishRelayProperty.swift in Sources */,
 				241B4EEA26D3B3F4000409CC /* SideMenuActionItemView.swift in Sources */,
 				2D4ADCC926C61192008F8843 /* FeedsViewModel.swift in Sources */,
+				2424B22F26D4A2EF00CF07B5 /* LoginViewModel.swift in Sources */,
 				2DE3B9B526C1339200272775 /* Typealias.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/NimbleMedium/Resources/en.lproj/Localizable.strings
+++ b/NimbleMedium/Resources/en.lproj/Localizable.strings
@@ -11,12 +11,11 @@
 "feed.title" = "Feed";
 
 "login.title" = "Login";
-"login.textfield.email.hint" = "Email";
-"login.textfield.password.hint" = "Password";
-"login.needaccount.title" = "Need an account?";
+"login.textFieldEmail.placeholder" = "Email";
+"login.textfieldPassword.placeholder" = "Password";
+"login.needAccount.title" = "Need an account?";
 
 "menu.header.title" = "Nimble Medium";
 "menu.header.description" = "A place to share your knowledge";
 "menu.option.login" = "Login";
-
 "menu.option.signup" = "Signup";

--- a/NimbleMedium/Resources/en.lproj/Localizable.strings
+++ b/NimbleMedium/Resources/en.lproj/Localizable.strings
@@ -6,12 +6,17 @@
   
 */
 
+"action.login" = "Login";
+
 "feed.title" = "Feed";
 
+"login.title" = "Login";
+"login.textfield.email.hint" = "Email";
+"login.textfield.password.hint" = "Password";
+"login.needaccount.title" = "Need an account?";
+
 "menu.header.title" = "Nimble Medium";
-
 "menu.header.description" = "A place to share your knowledge";
-
 "menu.option.login" = "Login";
 
 "menu.option.signup" = "Signup";

--- a/NimbleMedium/Sources/Presentation/Modules/Home/HomeView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Home/HomeView.swift
@@ -41,9 +41,9 @@ struct HomeView: View {
             HStack {
                 GeometryReader { geo in
                     SideMenuView()
-                        .frame(width: geo.size.width * 2 / 3, height: geo.size.height)
+                        .frame(width: geo.size.width * 2.0 / 3.0, height: geo.size.height)
                         .background(Color.white)
-                        .offset(x: isSideMenuOpen ? 0 : -geo.size.width * 2 / 3)
+                        .offset(x: isSideMenuOpen ? 0.0 : -geo.size.width * 2.0 / 3.0)
                         .animation(.easeIn(duration: 0.5))
                 }
             }

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
@@ -23,7 +23,7 @@ struct LoginView: View {
     var body: some View {
         NavigationView {
             VStack(spacing: 15.0) {
-                TextField(Localizable.loginTextfieldEmailHint(), text: $email)
+                TextField(Localizable.loginTextFieldEmailPlaceholder(), text: $email)
                     .padding()
                     .overlay(
                         RoundedRectangle(cornerRadius: 8.0)
@@ -31,7 +31,7 @@ struct LoginView: View {
                     )
                     .keyboardType(.emailAddress)
                     .accentColor(.black)
-                SecureField(Localizable.loginTextfieldPasswordHint(), text: $password)
+                SecureField(Localizable.loginTextfieldPasswordPlaceholder(), text: $password)
                     .padding()
                     .overlay(
                         RoundedRectangle(cornerRadius: 8.0)
@@ -47,12 +47,12 @@ struct LoginView: View {
                     }
                 )
                 .background(Color.green)
-                .cornerRadius(8)
+                .cornerRadius(8.0)
                 Button(
                     action: {
                         // TODO: Implement in integrate task
                     }, label: {
-                        Text(Localizable.loginNeedaccountTitle())
+                        Text(Localizable.loginNeedAccountTitle())
                             .frame(height: 25.0)
                     }
                 )

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
@@ -28,14 +28,17 @@ struct LoginView: View {
                     .padding()
                     .overlay(
                         RoundedRectangle(cornerRadius: 8)
-                            .stroke(Color(UIColor.lightGray), lineWidth: 2)
+                            .stroke(Color(UIColor.lightGray), lineWidth: 1)
                     )
-                TextField(Localizable.loginTextfieldPasswordHint(), text: $password)
+                    .keyboardType(.emailAddress)
+                    .accentColor(.black)
+                SecureField(Localizable.loginTextfieldPasswordHint(), text: $password)
                     .padding()
                     .overlay(
                         RoundedRectangle(cornerRadius: 8)
-                            .stroke(Color(UIColor.lightGray), lineWidth: 2)
+                            .stroke(Color(UIColor.lightGray), lineWidth: 1)
                     )
+                    .accentColor(.black)
                 Button(
                     action: {
                         // TODO: Implement in integrate task

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
@@ -17,26 +17,25 @@ struct LoginView: View {
     // swiftlint:disable type_contents_order
     init(viewModel: LoginViewModelProtocol) {
         self.viewModel = viewModel
-        UIBarButtonItem.appearance(whenContainedInInstancesOf: [UIToolbar.self]).tintColor = .white
     }
 
     // swiftlint:disable closure_body_length
     var body: some View {
         NavigationView {
-            VStack(spacing: 15) {
+            VStack(spacing: 15.0) {
                 TextField(Localizable.loginTextfieldEmailHint(), text: $email)
                     .padding()
                     .overlay(
-                        RoundedRectangle(cornerRadius: 8)
-                            .stroke(Color(UIColor.lightGray), lineWidth: 1)
+                        RoundedRectangle(cornerRadius: 8.0)
+                            .stroke(Color(UIColor.lightGray), lineWidth: 1.0)
                     )
                     .keyboardType(.emailAddress)
                     .accentColor(.black)
                 SecureField(Localizable.loginTextfieldPasswordHint(), text: $password)
                     .padding()
                     .overlay(
-                        RoundedRectangle(cornerRadius: 8)
-                            .stroke(Color(UIColor.lightGray), lineWidth: 1)
+                        RoundedRectangle(cornerRadius: 8.0)
+                            .stroke(Color(UIColor.lightGray), lineWidth: 1.0)
                     )
                     .accentColor(.black)
                 Button(
@@ -44,7 +43,7 @@ struct LoginView: View {
                         // TODO: Implement in integrate task
                     }, label: {
                         Text(Localizable.actionLogin())
-                            .frame(width: 100, height: 50)
+                            .frame(width: 100.0, height: 50.0)
                     }
                 )
                 .background(Color.green)
@@ -54,7 +53,7 @@ struct LoginView: View {
                         // TODO: Implement in integrate task
                     }, label: {
                         Text(Localizable.loginNeedaccountTitle())
-                            .frame(height: 25)
+                            .frame(height: 25.0)
                     }
                 )
                 .foregroundColor(.green)

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
@@ -1,0 +1,90 @@
+//
+//  LoginView.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 24/08/2021.
+//
+
+import SwiftUI
+
+struct LoginView: View {
+
+    @State private var email = ""
+    @State private var password = ""
+
+    private let viewModel: LoginViewModelProtocol
+
+    // swiftlint:disable type_contents_order
+    init(viewModel: LoginViewModelProtocol) {
+        self.viewModel = viewModel
+        UIBarButtonItem.appearance(whenContainedInInstancesOf: [UIToolbar.self]).tintColor = .white
+    }
+
+    // swiftlint:disable closure_body_length
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 15) {
+                TextField(Localizable.loginTextfieldEmailHint(), text: $email)
+                    .padding()
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color(UIColor.lightGray), lineWidth: 2)
+                    )
+                TextField(Localizable.loginTextfieldPasswordHint(), text: $password)
+                    .padding()
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color(UIColor.lightGray), lineWidth: 2)
+                    )
+                Button(
+                    action: {
+                        // TODO: Implement in integrate task
+                    }, label: {
+                        Text(Localizable.actionLogin())
+                            .frame(width: 100, height: 50)
+                    }
+                )
+                .background(Color.green)
+                .cornerRadius(8)
+                Button(
+                    action: {
+                        // TODO: Implement in integrate task
+                    }, label: {
+                        Text(Localizable.loginNeedaccountTitle())
+                            .frame(height: 25)
+                    }
+                )
+                .foregroundColor(.green)
+            }
+            .padding()
+            .navigationTitle(Localizable.loginTitle())
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarColor(backgroundColor: .green)
+            .toolbar { navigationBarLeadingContent }
+        }.accentColor(.white)
+
+    }
+
+    var navigationBarLeadingContent: some ToolbarContent {
+        ToolbarItem(placement: .navigationBarLeading) {
+            Button(
+                action: {
+                    // TODO: Implement in integrate task
+                },
+                label: {
+                    Image(systemName: "xmark")
+                }
+            )
+        }
+    }
+}
+
+#if DEBUG
+struct LoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        let viewModel = LoginViewModel()
+
+        return LoginView(viewModel: viewModel)
+    }
+}
+#endif

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginViewModel.swift
@@ -1,0 +1,35 @@
+//
+//  LoginViewModel.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 24/08/2021.
+//
+
+import RxSwift
+
+protocol LoginViewModelInput {
+
+    // TODO: To be implemented
+}
+
+protocol LoginViewModelOutput {
+
+    // TODO: To be implemented
+}
+
+protocol LoginViewModelProtocol {
+
+    var input: LoginViewModelInput { get }
+    var output: LoginViewModelOutput { get }
+}
+
+final class LoginViewModel: LoginViewModelProtocol {
+
+    var input: LoginViewModelInput { self }
+    var output: LoginViewModelOutput { self }
+
+}
+
+extension LoginViewModel: LoginViewModelInput { }
+
+extension LoginViewModel: LoginViewModelOutput { }

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActionItemView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActionItemView.swift
@@ -14,7 +14,7 @@ struct SideMenuActionItemView: View {
     
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 10) {
+            HStack(spacing: 10.0) {
                 Image(iconName)
                     .resizable()
                     .frame(width: 25.0, height: 25.0)


### PR DESCRIPTION
Resolved #24 

## What happened

For the existing users of the application that don't login yet, they should be able to login into the application for being able use more features and manage personal contents.

## Insight

- [x] Add the top navigation bar by reusing the UI layout from #7.
- [x] Add the `Close` button on the left of the top navigation bar.
- [x] Update the navigation bar title with text: `Login`.
- [x] Add 2 vertical text fields: `Email`, `Password` and center them horizontally in the screen as shown in the provided design.
- [x] Apply the email keyboard style for `Email` text field.
- [x] Apply the password keyboard style for `Password` text field.
- [x] Add the `Login` button below the `Password` text field, center it horizontally in the screen and use the color and styles from the provided design.
- [x] Add the `Need an account?` button below the `Login` button, center it horizontally in the screen and use the color and styles from the provided design.
- [x] Group all the text fields and buttons and center them vertically in the screen.
- [x] Dismiss the keyboard when it is active and users tap on the outside region. **(Implemented on #114)**

## Proof Of Work

<img src="https://user-images.githubusercontent.com/70877098/130561501-caf5623f-26d6-4baa-a759-b7ec1cb73509.jpeg" width="300">


