### PR TITLE
[#26] As a user, I can signup from the left menu

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -37,6 +37,9 @@
 		249042FA26D510A300E970B6 /* DependencyFactory+ViewModelFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249042F926D510A300E970B6 /* DependencyFactory+ViewModelFactoryProtocol.swift */; };
 		2497356126D34F3200177A7C /* SideMenuActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2497356026D34F3200177A7C /* SideMenuActionsView.swift */; };
 		2497356326D35BBD00177A7C /* MenuOptionButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */; };
+		24C9393926D89FA300547800 /* AuthTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C9393826D89FA300547800 /* AuthTextFieldView.swift */; };
+		24C9393B26D8A1A200547800 /* AuthSecureFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C9393A26D8A1A200547800 /* AuthSecureFieldView.swift */; };
+		24C9393D26D8A26300547800 /* AppMainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C9393C26D8A26300547800 /* AppMainButton.swift */; };
 		2D2F456026C25911002C0331 /* View+NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D2F455F26C25911002C0331 /* View+NavigationBar.swift */; };
 		2D303B3B26C28AC200EEF1C0 /* Constants+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D303B3A26C28AC200EEF1C0 /* Constants+String.swift */; };
 		2D467C3D26BCD58D008F11E1 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D467C3C26BCD58D008F11E1 /* HomeView.swift */; };
@@ -119,6 +122,9 @@
 		249042F926D510A300E970B6 /* DependencyFactory+ViewModelFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DependencyFactory+ViewModelFactoryProtocol.swift"; sourceTree = "<group>"; };
 		2497356026D34F3200177A7C /* SideMenuActionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionsView.swift; sourceTree = "<group>"; };
 		2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionButtonStyle.swift; sourceTree = "<group>"; };
+		24C9393826D89FA300547800 /* AuthTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTextFieldView.swift; sourceTree = "<group>"; };
+		24C9393A26D8A1A200547800 /* AuthSecureFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSecureFieldView.swift; sourceTree = "<group>"; };
+		24C9393C26D8A26300547800 /* AppMainButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMainButton.swift; sourceTree = "<group>"; };
 		2D2F455F26C25911002C0331 /* View+NavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+NavigationBar.swift"; sourceTree = "<group>"; };
 		2D303B3A26C28AC200EEF1C0 /* Constants+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Constants+String.swift"; sourceTree = "<group>"; };
 		2D467C3C26BCD58D008F11E1 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
@@ -480,6 +486,9 @@
 		2D72E48326C218D300861239 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				24C9393C26D8A26300547800 /* AppMainButton.swift */,
+				24C9393A26D8A1A200547800 /* AuthSecureFieldView.swift */,
+				24C9393826D89FA300547800 /* AuthTextFieldView.swift */,
 				24204C9D26D5289900534314 /* Background.swift */,
 			);
 			path = Views;
@@ -1272,6 +1281,7 @@
 				249042F826D5104E00E970B6 /* DependencyFactory.swift in Sources */,
 				2D303B3B26C28AC200EEF1C0 /* Constants+String.swift in Sources */,
 				24204CA226D62B6900534314 /* SideMenuViewModel.swift in Sources */,
+				24C9393B26D8A1A200547800 /* AuthSecureFieldView.swift in Sources */,
 				249042E726D4D14F00E970B6 /* SignupViewModel.swift in Sources */,
 				246A8FB826D39C24009F9753 /* SideMenuHeaderView.swift in Sources */,
 				2459B32226D750E200ABCE61 /* AuthRepositoryProtocol.swift in Sources */,
@@ -1292,6 +1302,7 @@
 				2459B32626D7512300ABCE61 /* User.swift in Sources */,
 				2D4ADCC426C60940008F8843 /* HomeViewModel.swift in Sources */,
 				2DD4805726D73C67005225CF /* ObservableViewModel.swift in Sources */,
+				24C9393D26D8A26300547800 /* AppMainButton.swift in Sources */,
 				2497356326D35BBD00177A7C /* MenuOptionButtonStyle.swift in Sources */,
 				2D5485B726C9FAAC00FFE707 /* BehaviorRelayProperty.swift in Sources */,
 				2D69824426C22DC700860A98 /* R.generated.swift in Sources */,
@@ -1300,6 +1311,7 @@
 				2497356126D34F3200177A7C /* SideMenuActionsView.swift in Sources */,
 				2459B32826D751E300ABCE61 /* LoginUseCase.swift in Sources */,
 				2424B22C26D4A22B00CF07B5 /* LoginView.swift in Sources */,
+				24C9393926D89FA300547800 /* AuthTextFieldView.swift in Sources */,
 				249042F626D50FF300E970B6 /* ViewModelFactoryProtocol.swift in Sources */,
 				2DA4ABBF26CF90D000CF7D68 /* AppEnvironment.swift in Sources */,
 				2D5485BC26CA077600FFE707 /* View+OnReceive.swift in Sources */,

--- a/NimbleMedium/Sources/Factories/Application/DependencyFactory+ViewModelFactoryProtocol.swift
+++ b/NimbleMedium/Sources/Factories/Application/DependencyFactory+ViewModelFactoryProtocol.swift
@@ -26,4 +26,8 @@ extension DependencyFactory: ViewModelFactoryProtocol {
     func sideMenuViewModel() -> SideMenuViewModelProtocol {
         SideMenuViewModel(factory: self)
     }
+
+    func signupViewModel() -> SignupViewModelProtocol {
+        SignupViewModel()
+    }
 }

--- a/NimbleMedium/Sources/Factories/Presentation/ViewModelFactoryProtocol.swift
+++ b/NimbleMedium/Sources/Factories/Presentation/ViewModelFactoryProtocol.swift
@@ -16,4 +16,6 @@ protocol ViewModelFactoryProtocol {
     func sideMenuActionsViewModel() -> SideMenuActionsViewModelProtocol
 
     func sideMenuViewModel() -> SideMenuViewModelProtocol
+
+    func signupViewModel() -> SignupViewModelProtocol
 }

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct LoginView: View {
 
     @Environment(\.presentationMode) var presentationMode
+
     @State private var email = ""
     @State private var password = ""
 

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
@@ -21,12 +21,12 @@ struct LoginView: View {
             Background {
                 VStack(spacing: 15.0) {
                     AuthTextFieldView(
-                        placeHolderText: Localizable.loginTextFieldEmailPlaceholder(),
+                        placeholder: Localizable.loginTextFieldEmailPlaceholder(),
                         text: $email,
                         supportEmailKeyboard: true
                     )
                     AuthSecureFieldView(
-                        placeHolderText: Localizable.loginTextfieldPasswordPlaceholder(),
+                        placeholder: Localizable.loginTextfieldPasswordPlaceholder(),
                         text: $password)
                     AppMainButton(title: Localizable.actionLogin()) {
                         // TODO: Implement in integrate task

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
@@ -16,36 +16,21 @@ struct LoginView: View {
 
     @ObservedViewModel var viewModel: LoginViewModelProtocol
 
-    // swiftlint:disable closure_body_length
     var body: some View {
         NavigationView {
             Background {
                 VStack(spacing: 15.0) {
-                    TextField(Localizable.loginTextFieldEmailPlaceholder(), text: $email)
-                        .padding()
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8.0)
-                                .stroke(Color(UIColor.lightGray), lineWidth: 1.0)
-                        )
-                        .keyboardType(.emailAddress)
-                        .accentColor(.black)
-                    SecureField(Localizable.loginTextfieldPasswordPlaceholder(), text: $password)
-                        .padding()
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8.0)
-                                .stroke(Color(UIColor.lightGray), lineWidth: 1.0)
-                        )
-                        .accentColor(.black)
-                    Button(
-                        action: {
-                            // TODO: Implement in integrate task
-                        }, label: {
-                            Text(Localizable.actionLogin())
-                                .frame(width: 100.0, height: 50.0)
-                        }
+                    AuthTextFieldView(
+                        placeHolderText: Localizable.loginTextFieldEmailPlaceholder(),
+                        text: $email,
+                        supportEmailKeyboard: true
                     )
-                    .background(Color.green)
-                    .cornerRadius(8.0)
+                    AuthSecureFieldView(
+                        placeHolderText: Localizable.loginTextfieldPasswordPlaceholder(),
+                        text: $password)
+                    AppMainButton(title: Localizable.actionLogin()) {
+                        // TODO: Implement in integrate task
+                    }
                     Button(
                         action: {
                             // TODO: Implement in integrate task
@@ -64,7 +49,6 @@ struct LoginView: View {
             .toolbar { navigationBarLeadingContent }
         }
         .accentColor(.white)
-
     }
 
     var navigationBarLeadingContent: some ToolbarContent {

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsView.swift
@@ -14,6 +14,7 @@ struct SideMenuActionsView: View {
 
     @State private var isAuthenticated = false
     @State private var isShowingLoginScreen = false
+    @State private var isShowingSignupScreen = false
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -32,12 +33,18 @@ struct SideMenuActionsView: View {
                     text: Localizable.menuOptionSignup(),
                     iconName: R.image.iconSignup.name
                 ) {
-                    print("Signup button was tapped")
+                    viewModel.input.selectSignupOption()
+                }
+                .fullScreenCover(isPresented: $isShowingSignupScreen) {
+                    SignupView(viewModel: viewModel.output.signupViewModel)
                 }
             }
         }
         .onReceive(viewModel.output.didSelectLoginOption) {
             isShowingLoginScreen = $0
+        }
+        .onReceive(viewModel.output.didSelectSignupOption) {
+            isShowingSignupScreen = $0
         }
     }
 

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
@@ -12,12 +12,15 @@ import Combine
 protocol SideMenuActionsViewModelInput {
 
     func selectLoginOption()
+    func selectSignupOption()
 }
 
 protocol SideMenuActionsViewModelOutput {
 
     var didSelectLoginOption: Signal<Bool> { get }
+    var didSelectSignupOption: Signal<Bool> { get }
     var loginViewModel: LoginViewModelProtocol { get }
+    var signupViewModel: SignupViewModelProtocol { get }
 }
 
 protocol SideMenuActionsViewModelProtocol: ObservableViewModel {
@@ -32,11 +35,14 @@ final class SideMenuActionsViewModel: ObservableObject, SideMenuActionsViewModel
     var output: SideMenuActionsViewModelOutput { self }
 
     @PublishRelayProperty var didSelectLoginOption: Signal<Bool>
+    @PublishRelayProperty var didSelectSignupOption: Signal<Bool>
 
     let loginViewModel: LoginViewModelProtocol
+    let signupViewModel: SignupViewModelProtocol
 
     init(factory: ModuleFactoryProtocol) {
         loginViewModel = factory.loginViewModel()
+        signupViewModel = factory.signupViewModel()
     }
 }
 
@@ -44,6 +50,10 @@ extension SideMenuActionsViewModel: SideMenuActionsViewModelInput {
 
     func selectLoginOption() {
         $didSelectLoginOption.accept(true)
+    }
+
+    func selectSignupOption() {
+        $didSelectSignupOption.accept(true)
     }
 }
 

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuMain/SideMenuViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuMain/SideMenuViewModel.swift
@@ -45,6 +45,12 @@ final class SideMenuViewModel: ObservableObject, SideMenuViewModelProtocol {
                 self.$didSelectMenuOption.accept(())
             }
             .disposed(by: disposeBag)
+        sideMenuActionsViewModel.output.didSelectSignupOption.asObservable()
+            .withUnretained(self)
+            .bind { _ in
+                self.$didSelectMenuOption.accept(())
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct SignupView: View {
 
+    @Environment(\.presentationMode) var presentationMode
+
     @State private var email = ""
     @State private var password = ""
     @State private var username = ""
@@ -18,62 +20,64 @@ struct SignupView: View {
     // swiftlint:disable closure_body_length
     var body: some View {
         NavigationView {
-            VStack(spacing: 15.0) {
-                TextField(Localizable.signupTextFieldUsernamePlaceholder(), text: $username)
-                    .padding()
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8.0)
-                            .stroke(Color(.lightGray), lineWidth: 1.0)
+            Background {
+                VStack(spacing: 15.0) {
+                    TextField(Localizable.signupTextFieldUsernamePlaceholder(), text: $username)
+                        .padding()
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8.0)
+                                .stroke(Color(.lightGray), lineWidth: 1.0)
+                        )
+                        .accentColor(.black)
+                    TextField(Localizable.signupTextFieldEmailPlaceholder(), text: $email)
+                        .padding()
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8.0)
+                                .stroke(Color(.lightGray), lineWidth: 1.0)
+                        )
+                        .keyboardType(.emailAddress)
+                        .accentColor(.black)
+                    SecureField(Localizable.signupTextFieldPasswordPlaceholder(), text: $password)
+                        .padding()
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8.0)
+                                .stroke(Color(.lightGray), lineWidth: 1.0)
+                        )
+                        .accentColor(.black)
+                    Button(
+                        action: {
+                            // TODO: Implement in integrate task
+                        }, label: {
+                            Text(Localizable.actionSignup())
+                                .frame(width: 100.0, height: 50.0)
+                        }
                     )
-                    .accentColor(.black)
-                TextField(Localizable.signupTextFieldEmailPlaceholder(), text: $email)
-                    .padding()
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8.0)
-                            .stroke(Color(.lightGray), lineWidth: 1.0)
+                    .background(Color.green)
+                    .cornerRadius(8.0)
+                    Button(
+                        action: {
+                            // TODO: Implement in integrate task
+                        }, label: {
+                            Text(Localizable.signupHaveAccountTitle())
+                                .frame(height: 25.0)
+                        }
                     )
-                    .keyboardType(.emailAddress)
-                    .accentColor(.black)
-                SecureField(Localizable.signupTextFieldPasswordPlaceholder(), text: $password)
-                    .padding()
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8.0)
-                            .stroke(Color(.lightGray), lineWidth: 1.0)
-                    )
-                    .accentColor(.black)
-                Button(
-                    action: {
-                        // TODO: Implement in integrate task
-                    }, label: {
-                        Text(Localizable.actionSignup())
-                            .frame(width: 100.0, height: 50.0)
-                    }
-                )
-                .background(Color.green)
-                .cornerRadius(8.0)
-                Button(
-                    action: {
-                        // TODO: Implement in integrate task
-                    }, label: {
-                        Text(Localizable.signupHaveAccountTitle())
-                            .frame(height: 25.0)
-                    }
-                )
-                .foregroundColor(.green)
+                    .foregroundColor(.green)
+                }
             }
+            .onTapGesture { hideKeyboard() }
             .navigationBarTitle(Localizable.signupTitle(), displayMode: .inline)
             .navigationBarColor(backgroundColor: .green)
             .toolbar { navigationBarLeadingContent }
         }
         .accentColor(.white)
-        .onTapGesture { hideKeyboard() }
     }
 
     var navigationBarLeadingContent: some ToolbarContent {
         ToolbarItem(placement: .navigationBarLeading) {
             Button(
                 action: {
-                    // TODO: Implement in integrate task
+                    presentationMode.wrappedValue.dismiss()
                 },
                 label: {
                     Image(systemName: SystemImageName.xmark.rawValue)

--- a/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
@@ -22,38 +22,21 @@ struct SignupView: View {
         NavigationView {
             Background {
                 VStack(spacing: 15.0) {
-                    TextField(Localizable.signupTextFieldUsernamePlaceholder(), text: $username)
-                        .padding()
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8.0)
-                                .stroke(Color(.lightGray), lineWidth: 1.0)
-                        )
-                        .accentColor(.black)
-                    TextField(Localizable.signupTextFieldEmailPlaceholder(), text: $email)
-                        .padding()
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8.0)
-                                .stroke(Color(.lightGray), lineWidth: 1.0)
-                        )
-                        .keyboardType(.emailAddress)
-                        .accentColor(.black)
-                    SecureField(Localizable.signupTextFieldPasswordPlaceholder(), text: $password)
-                        .padding()
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8.0)
-                                .stroke(Color(.lightGray), lineWidth: 1.0)
-                        )
-                        .accentColor(.black)
-                    Button(
-                        action: {
-                            // TODO: Implement in integrate task
-                        }, label: {
-                            Text(Localizable.actionSignup())
-                                .frame(width: 100.0, height: 50.0)
-                        }
+                    AuthTextFieldView(
+                        placeHolderText: Localizable.signupTextFieldUsernamePlaceholder(),
+                        text: $username
                     )
-                    .background(Color.green)
-                    .cornerRadius(8.0)
+                    AuthTextFieldView(
+                        placeHolderText: Localizable.signupTextFieldEmailPlaceholder(),
+                        text: $email,
+                        supportEmailKeyboard: true
+                    )
+                    AuthSecureFieldView(
+                        placeHolderText: Localizable.signupTextFieldPasswordPlaceholder(),
+                        text: $password)
+                    AppMainButton(title: Localizable.actionSignup()) {
+                        // TODO: Implement in integrate task
+                    }
                     Button(
                         action: {
                             // TODO: Implement in integrate task

--- a/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
@@ -23,16 +23,16 @@ struct SignupView: View {
             Background {
                 VStack(spacing: 15.0) {
                     AuthTextFieldView(
-                        placeHolderText: Localizable.signupTextFieldUsernamePlaceholder(),
+                        placeholder: Localizable.signupTextFieldUsernamePlaceholder(),
                         text: $username
                     )
                     AuthTextFieldView(
-                        placeHolderText: Localizable.signupTextFieldEmailPlaceholder(),
+                        placeholder: Localizable.signupTextFieldEmailPlaceholder(),
                         text: $email,
                         supportEmailKeyboard: true
                     )
                     AuthSecureFieldView(
-                        placeHolderText: Localizable.signupTextFieldPasswordPlaceholder(),
+                        placeholder: Localizable.signupTextFieldPasswordPlaceholder(),
                         text: $password)
                     AppMainButton(title: Localizable.actionSignup()) {
                         // TODO: Implement in integrate task

--- a/NimbleMedium/Sources/Presentation/Views/AppMainButton.swift
+++ b/NimbleMedium/Sources/Presentation/Views/AppMainButton.swift
@@ -1,0 +1,27 @@
+//
+//  NimbleMediumMainButton.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 27/08/2021.
+//
+
+import SwiftUI
+
+struct AppMainButton: View {
+
+    private var title: String
+    private var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title).frame(width: 100.0, height: 50.0)
+        }
+        .background(Color.green)
+        .cornerRadius(8.0)
+    }
+
+    init(title: String, action: @escaping () -> Void) {
+        self.title = title
+        self.action = action
+    }
+}

--- a/NimbleMedium/Sources/Presentation/Views/AuthSecureFieldView.swift
+++ b/NimbleMedium/Sources/Presentation/Views/AuthSecureFieldView.swift
@@ -1,0 +1,29 @@
+//
+//  AuthSecureFieldView.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 27/08/2021.
+//
+
+import SwiftUI
+
+struct AuthSecureFieldView: View {
+
+    private var placeHolderText: String
+    private var text: Binding<String>
+
+    var body: some View {
+        SecureField(placeHolderText, text: text)
+            .padding()
+            .overlay(
+                RoundedRectangle(cornerRadius: 8.0)
+                    .stroke(Color(.lightGray), lineWidth: 1.0)
+            )
+            .accentColor(.black)
+    }
+
+    init(placeHolderText: String, text: Binding<String>) {
+        self.placeHolderText = placeHolderText
+        self.text = text
+    }
+}

--- a/NimbleMedium/Sources/Presentation/Views/AuthSecureFieldView.swift
+++ b/NimbleMedium/Sources/Presentation/Views/AuthSecureFieldView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 struct AuthSecureFieldView: View {
 
-    private var placeHolderText: String
+    private var placeholder: String
     private var text: Binding<String>
 
     var body: some View {
-        SecureField(placeHolderText, text: text)
+        SecureField(placeholder, text: text)
             .padding()
             .overlay(
                 RoundedRectangle(cornerRadius: 8.0)
@@ -22,8 +22,8 @@ struct AuthSecureFieldView: View {
             .accentColor(.black)
     }
 
-    init(placeHolderText: String, text: Binding<String>) {
-        self.placeHolderText = placeHolderText
+    init(placeholder: String, text: Binding<String>) {
+        self.placeholder = placeholder
         self.text = text
     }
 }

--- a/NimbleMedium/Sources/Presentation/Views/AuthTextFieldView.swift
+++ b/NimbleMedium/Sources/Presentation/Views/AuthTextFieldView.swift
@@ -1,0 +1,32 @@
+//
+//  AuthTextFieldView.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 27/08/2021.
+//
+
+import SwiftUI
+
+struct AuthTextFieldView: View {
+
+    private var placeHolderText: String
+    private var text: Binding<String>
+    private var supportEmailKeyboard: Bool
+
+    var body: some View {
+        TextField(placeHolderText, text: text)
+            .padding()
+            .overlay(
+                RoundedRectangle(cornerRadius: 8.0)
+                    .stroke(Color(.lightGray), lineWidth: 1.0)
+            )
+            .keyboardType(supportEmailKeyboard ? .emailAddress : .default)
+            .accentColor(.black)
+    }
+
+    init(placeHolderText: String, text: Binding<String>, supportEmailKeyboard: Bool = false) {
+        self.placeHolderText = placeHolderText
+        self.text = text
+        self.supportEmailKeyboard = supportEmailKeyboard
+    }
+}

--- a/NimbleMedium/Sources/Presentation/Views/AuthTextFieldView.swift
+++ b/NimbleMedium/Sources/Presentation/Views/AuthTextFieldView.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 struct AuthTextFieldView: View {
 
-    private var placeHolderText: String
+    private var placeholder: String
     private var text: Binding<String>
     private var supportEmailKeyboard: Bool
 
     var body: some View {
-        TextField(placeHolderText, text: text)
+        TextField(placeholder, text: text)
             .padding()
             .overlay(
                 RoundedRectangle(cornerRadius: 8.0)
@@ -24,8 +24,8 @@ struct AuthTextFieldView: View {
             .accentColor(.black)
     }
 
-    init(placeHolderText: String, text: Binding<String>, supportEmailKeyboard: Bool = false) {
-        self.placeHolderText = placeHolderText
+    init(placeholder: String, text: Binding<String>, supportEmailKeyboard: Bool = false) {
+        self.placeholder = placeholder
         self.text = text
         self.supportEmailKeyboard = supportEmailKeyboard
     }


### PR DESCRIPTION
Resolved #26 

## What happened

For the new users of the application, they should be able to see the `Signup` screen for being able to create a new account, explore and use more features from the application.

## Insight

- [x] The `Signup` option is only visible when users are not logged in. Hide it when they are authenticated to the app.
- [x] When the users tap on the `Signup` option from the left menu of the `Home` screen, toggle to hide the left menu and present the common `Signup` screen modally.
- [x] When the users tap on the `Close` button in  the `Signup` screen, dismiss it modally.

## Proof Of Work

https://user-images.githubusercontent.com/70877098/130801134-0b4b9259-5c84-41f8-9a25-61c26f451b45.mov




