### PR TITLE
[Chore] Add Debug configuration for Staging and Production schemes

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 
 /* Begin PBXFileReference section */
 		182CA8AF5AD16C128ADBB7D6 /* Pods-NimbleMediumTests.debug production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.debug production.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.debug production.xcconfig"; sourceTree = "<group>"; };
+		1B8DA573BF5543E0BD2D9E94 /* Pods-NimbleMediumTests.release production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.release production.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.release production.xcconfig"; sourceTree = "<group>"; };
 		1FB4ECE354F839DF02D6976B /* Pods-NimbleMedium.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.staging.xcconfig"; sourceTree = "<group>"; };
 		21851292A064EB97674233A2 /* Pods-NimbleMediumTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.staging.xcconfig"; sourceTree = "<group>"; };
 		241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionItemView.swift; sourceTree = "<group>"; };
@@ -154,13 +155,18 @@
 		44CDBEC74AB6205DBE05C61C /* Pods-NimbleMedium.debug staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.debug staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.debug staging.xcconfig"; sourceTree = "<group>"; };
 		458DD8FDDDFB794337C4FC53 /* Pods-NimbleMedium-NimbleMediumUITests.debug staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium-NimbleMediumUITests.debug staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium-NimbleMediumUITests/Pods-NimbleMedium-NimbleMediumUITests.debug staging.xcconfig"; sourceTree = "<group>"; };
 		664F4E0BC9D9E468E0506C22 /* Pods-NimbleMediumTests.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.production.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.production.xcconfig"; sourceTree = "<group>"; };
+		6C74D9380DB6E2E950FBE751 /* Pods-NimbleMedium-NimbleMediumUITests.release production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium-NimbleMediumUITests.release production.xcconfig"; path = "Target Support Files/Pods-NimbleMedium-NimbleMediumUITests/Pods-NimbleMedium-NimbleMediumUITests.release production.xcconfig"; sourceTree = "<group>"; };
+		6D135778E77723C90B50C7AE /* Pods-NimbleMedium-NimbleMediumUITests.release staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium-NimbleMediumUITests.release staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium-NimbleMediumUITests/Pods-NimbleMedium-NimbleMediumUITests.release staging.xcconfig"; sourceTree = "<group>"; };
 		6E41E63B326C526EFD5BA685 /* Pods-NimbleMedium.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.production.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.production.xcconfig"; sourceTree = "<group>"; };
 		6FED2492E982E731BBE5E9E3 /* Pods-NimbleMediumTests.debug staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.debug staging.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.debug staging.xcconfig"; sourceTree = "<group>"; };
 		74B1A182D909036C2150D5D4 /* Pods-NimbleMedium.debug production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.debug production.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.debug production.xcconfig"; sourceTree = "<group>"; };
+		7721D3A180343F97BC0BD592 /* Pods-NimbleMedium.release production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.release production.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.release production.xcconfig"; sourceTree = "<group>"; };
 		8319E63645C8E624FA94506E /* Pods_NimbleMedium.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NimbleMedium.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		901D8FC4774E2CF838738DEF /* Pods_NimbleMedium_NimbleMediumUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NimbleMedium_NimbleMediumUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A7FB373E4466876E4BD8212F /* Pods-NimbleMedium-NimbleMediumUITests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium-NimbleMediumUITests.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium-NimbleMediumUITests/Pods-NimbleMedium-NimbleMediumUITests.staging.xcconfig"; sourceTree = "<group>"; };
+		A91E5DE669974AF035856583 /* Pods-NimbleMediumTests.release staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.release staging.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.release staging.xcconfig"; sourceTree = "<group>"; };
 		B350D67E0CE0AD97820184FA /* Pods-NimbleMedium-NimbleMediumUITests.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium-NimbleMediumUITests.production.xcconfig"; path = "Target Support Files/Pods-NimbleMedium-NimbleMediumUITests/Pods-NimbleMedium-NimbleMediumUITests.production.xcconfig"; sourceTree = "<group>"; };
+		BE1BC57CAF7CE750801CC99B /* Pods-NimbleMedium.release staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.release staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.release staging.xcconfig"; sourceTree = "<group>"; };
 		EDBC77E99D264744421CC502 /* Pods_NimbleMediumTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NimbleMediumTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8C7D82B80C1CA5F14A914F4 /* Pods-NimbleMedium-NimbleMediumUITests.debug production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium-NimbleMediumUITests.debug production.xcconfig"; path = "Target Support Files/Pods-NimbleMedium-NimbleMediumUITests/Pods-NimbleMedium-NimbleMediumUITests.debug production.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -913,6 +919,12 @@
 				F8C7D82B80C1CA5F14A914F4 /* Pods-NimbleMedium-NimbleMediumUITests.debug production.xcconfig */,
 				6FED2492E982E731BBE5E9E3 /* Pods-NimbleMediumTests.debug staging.xcconfig */,
 				182CA8AF5AD16C128ADBB7D6 /* Pods-NimbleMediumTests.debug production.xcconfig */,
+				BE1BC57CAF7CE750801CC99B /* Pods-NimbleMedium.release staging.xcconfig */,
+				7721D3A180343F97BC0BD592 /* Pods-NimbleMedium.release production.xcconfig */,
+				6D135778E77723C90B50C7AE /* Pods-NimbleMedium-NimbleMediumUITests.release staging.xcconfig */,
+				6C74D9380DB6E2E950FBE751 /* Pods-NimbleMedium-NimbleMediumUITests.release production.xcconfig */,
+				A91E5DE669974AF035856583 /* Pods-NimbleMediumTests.release staging.xcconfig */,
+				1B8DA573BF5543E0BD2D9E94 /* Pods-NimbleMediumTests.release production.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -1131,7 +1143,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "PATH_TO_GOOGLE_PLISTS=\"$SRCROOT/$PROJECT_NAME/Configurations/Plists/GoogleService\"\n\ncase \"${CONFIGURATION}\" in\n  \"Staging\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Staging/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  \"Debug Staging\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Staging/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  \"Debug Production\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Production/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  \"Production\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Production/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  *)\n    ;;\nesac\n";
+			shellScript = "PATH_TO_GOOGLE_PLISTS=\"$SRCROOT/$PROJECT_NAME/Configurations/Plists/GoogleService\"\n\ncase \"${CONFIGURATION}\" in\n  \"Release Staging\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Staging/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  \"Debug Staging\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Staging/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  \"Debug Production\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Production/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  \"Release Production\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Production/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  *)\n    ;;\nesac\n";
 		};
 		2DB726B726C117D500C16716 /* R.swift */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1147,7 +1159,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				$SRCROOT/$PROJECT_NAME/Sources/Supports/Helpers/R.generated.swift,
+				"$SRCROOT/$PROJECT_NAME/Sources/Supports/Helpers/R.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1351,7 +1363,7 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		24C9393E26D8D21200547800 /* Staging */ = {
+		24C9393E26D8D21200547800 /* Release Staging */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1411,11 +1423,11 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG STAGING";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
-			name = Staging;
+			name = "Release Staging";
 		};
-		24C9393F26D8D21200547800 /* Staging */ = {
+		24C9393F26D8D21200547800 /* Release Staging */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1FB4ECE354F839DF02D6976B /* Pods-NimbleMedium.staging.xcconfig */;
+			baseConfigurationReference = BE1BC57CAF7CE750801CC99B /* Pods-NimbleMedium.release staging.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1440,11 +1452,11 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Staging;
+			name = "Release Staging";
 		};
-		24C9394026D8D21200547800 /* Staging */ = {
+		24C9394026D8D21200547800 /* Release Staging */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 21851292A064EB97674233A2 /* Pods-NimbleMediumTests.staging.xcconfig */;
+			baseConfigurationReference = A91E5DE669974AF035856583 /* Pods-NimbleMediumTests.release staging.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -1466,11 +1478,11 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium.app/Nimble Medium";
 			};
-			name = Staging;
+			name = "Release Staging";
 		};
-		24C9394126D8D21200547800 /* Staging */ = {
+		24C9394126D8D21200547800 /* Release Staging */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A7FB373E4466876E4BD8212F /* Pods-NimbleMedium-NimbleMediumUITests.staging.xcconfig */;
+			baseConfigurationReference = 6D135778E77723C90B50C7AE /* Pods-NimbleMedium-NimbleMediumUITests.release staging.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -1490,9 +1502,9 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = NimbleMedium;
 			};
-			name = Staging;
+			name = "Release Staging";
 		};
-		24C9394226D8D22000547800 /* Production */ = {
+		24C9394226D8D22000547800 /* Release Production */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1547,11 +1559,11 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
 			};
-			name = Production;
+			name = "Release Production";
 		};
-		24C9394326D8D22000547800 /* Production */ = {
+		24C9394326D8D22000547800 /* Release Production */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E41E63B326C526EFD5BA685 /* Pods-NimbleMedium.production.xcconfig */;
+			baseConfigurationReference = 7721D3A180343F97BC0BD592 /* Pods-NimbleMedium.release production.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1574,11 +1586,11 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Production;
+			name = "Release Production";
 		};
-		24C9394426D8D22000547800 /* Production */ = {
+		24C9394426D8D22000547800 /* Release Production */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 664F4E0BC9D9E468E0506C22 /* Pods-NimbleMediumTests.production.xcconfig */;
+			baseConfigurationReference = 1B8DA573BF5543E0BD2D9E94 /* Pods-NimbleMediumTests.release production.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -1598,11 +1610,11 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium.app/Nimble Medium";
 			};
-			name = Production;
+			name = "Release Production";
 		};
-		24C9394526D8D22000547800 /* Production */ = {
+		24C9394526D8D22000547800 /* Release Production */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B350D67E0CE0AD97820184FA /* Pods-NimbleMedium-NimbleMediumUITests.production.xcconfig */;
+			baseConfigurationReference = 6C74D9380DB6E2E950FBE751 /* Pods-NimbleMedium-NimbleMediumUITests.release production.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -1621,7 +1633,7 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = NimbleMedium;
 			};
-			name = Production;
+			name = "Release Production";
 		};
 		2DB2676E26BBEC4500FF05BB /* Debug Production */ = {
 			isa = XCBuildConfiguration;
@@ -1902,45 +1914,45 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2DB2677826BBEE9D00FF05BB /* Debug Staging */,
-				24C9393E26D8D21200547800 /* Staging */,
+				24C9393E26D8D21200547800 /* Release Staging */,
 				2DB2676E26BBEC4500FF05BB /* Debug Production */,
-				24C9394226D8D22000547800 /* Production */,
+				24C9394226D8D22000547800 /* Release Production */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Production;
+			defaultConfigurationName = "Debug Staging";
 		};
 		2DB2676F26BBEC4500FF05BB /* Build configuration list for PBXNativeTarget "NimbleMedium" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2DB2677926BBEE9D00FF05BB /* Debug Staging */,
-				24C9393F26D8D21200547800 /* Staging */,
+				24C9393F26D8D21200547800 /* Release Staging */,
 				2DB2677126BBEC4500FF05BB /* Debug Production */,
-				24C9394326D8D22000547800 /* Production */,
+				24C9394326D8D22000547800 /* Release Production */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Production;
+			defaultConfigurationName = "Debug Staging";
 		};
 		2DB2677226BBEC4500FF05BB /* Build configuration list for PBXNativeTarget "NimbleMediumTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2DB2677A26BBEE9D00FF05BB /* Debug Staging */,
-				24C9394026D8D21200547800 /* Staging */,
+				24C9394026D8D21200547800 /* Release Staging */,
 				2DB2677426BBEC4500FF05BB /* Debug Production */,
-				24C9394426D8D22000547800 /* Production */,
+				24C9394426D8D22000547800 /* Release Production */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Production;
+			defaultConfigurationName = "Debug Staging";
 		};
 		2DB2677526BBEC4500FF05BB /* Build configuration list for PBXNativeTarget "NimbleMediumUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2DB2677B26BBEE9D00FF05BB /* Debug Staging */,
-				24C9394126D8D21200547800 /* Staging */,
+				24C9394126D8D21200547800 /* Release Staging */,
 				2DB2677726BBEC4500FF05BB /* Debug Production */,
-				24C9394526D8D22000547800 /* Production */,
+				24C9394526D8D22000547800 /* Release Production */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Production;
+			defaultConfigurationName = "Debug Staging";
 		};
 /* End XCConfigurationList section */
 	};

--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		182CA8AF5AD16C128ADBB7D6 /* Pods-NimbleMediumTests.debug production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.debug production.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.debug production.xcconfig"; sourceTree = "<group>"; };
 		1FB4ECE354F839DF02D6976B /* Pods-NimbleMedium.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.staging.xcconfig"; sourceTree = "<group>"; };
 		21851292A064EB97674233A2 /* Pods-NimbleMediumTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.staging.xcconfig"; sourceTree = "<group>"; };
 		241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionItemView.swift; sourceTree = "<group>"; };
@@ -150,13 +151,18 @@
 		2DD4805626D73C67005225CF /* ObservedViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservedViewModel.swift; sourceTree = "<group>"; };
 		2DDAD39F26D37E02007F845A /* App+NetworkLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App+NetworkLogger.swift"; sourceTree = "<group>"; };
 		2DE3B9B426C1339200272775 /* Typealias.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typealias.swift; sourceTree = "<group>"; };
+		44CDBEC74AB6205DBE05C61C /* Pods-NimbleMedium.debug staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.debug staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.debug staging.xcconfig"; sourceTree = "<group>"; };
+		458DD8FDDDFB794337C4FC53 /* Pods-NimbleMedium-NimbleMediumUITests.debug staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium-NimbleMediumUITests.debug staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium-NimbleMediumUITests/Pods-NimbleMedium-NimbleMediumUITests.debug staging.xcconfig"; sourceTree = "<group>"; };
 		664F4E0BC9D9E468E0506C22 /* Pods-NimbleMediumTests.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.production.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.production.xcconfig"; sourceTree = "<group>"; };
 		6E41E63B326C526EFD5BA685 /* Pods-NimbleMedium.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.production.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.production.xcconfig"; sourceTree = "<group>"; };
+		6FED2492E982E731BBE5E9E3 /* Pods-NimbleMediumTests.debug staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.debug staging.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.debug staging.xcconfig"; sourceTree = "<group>"; };
+		74B1A182D909036C2150D5D4 /* Pods-NimbleMedium.debug production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.debug production.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.debug production.xcconfig"; sourceTree = "<group>"; };
 		8319E63645C8E624FA94506E /* Pods_NimbleMedium.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NimbleMedium.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		901D8FC4774E2CF838738DEF /* Pods_NimbleMedium_NimbleMediumUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NimbleMedium_NimbleMediumUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A7FB373E4466876E4BD8212F /* Pods-NimbleMedium-NimbleMediumUITests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium-NimbleMediumUITests.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium-NimbleMediumUITests/Pods-NimbleMedium-NimbleMediumUITests.staging.xcconfig"; sourceTree = "<group>"; };
 		B350D67E0CE0AD97820184FA /* Pods-NimbleMedium-NimbleMediumUITests.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium-NimbleMediumUITests.production.xcconfig"; path = "Target Support Files/Pods-NimbleMedium-NimbleMediumUITests/Pods-NimbleMedium-NimbleMediumUITests.production.xcconfig"; sourceTree = "<group>"; };
 		EDBC77E99D264744421CC502 /* Pods_NimbleMediumTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NimbleMediumTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8C7D82B80C1CA5F14A914F4 /* Pods-NimbleMedium-NimbleMediumUITests.debug production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium-NimbleMediumUITests.debug production.xcconfig"; path = "Target Support Files/Pods-NimbleMedium-NimbleMediumUITests/Pods-NimbleMedium-NimbleMediumUITests.debug production.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -901,6 +907,12 @@
 				B350D67E0CE0AD97820184FA /* Pods-NimbleMedium-NimbleMediumUITests.production.xcconfig */,
 				21851292A064EB97674233A2 /* Pods-NimbleMediumTests.staging.xcconfig */,
 				664F4E0BC9D9E468E0506C22 /* Pods-NimbleMediumTests.production.xcconfig */,
+				44CDBEC74AB6205DBE05C61C /* Pods-NimbleMedium.debug staging.xcconfig */,
+				74B1A182D909036C2150D5D4 /* Pods-NimbleMedium.debug production.xcconfig */,
+				458DD8FDDDFB794337C4FC53 /* Pods-NimbleMedium-NimbleMediumUITests.debug staging.xcconfig */,
+				F8C7D82B80C1CA5F14A914F4 /* Pods-NimbleMedium-NimbleMediumUITests.debug production.xcconfig */,
+				6FED2492E982E731BBE5E9E3 /* Pods-NimbleMediumTests.debug staging.xcconfig */,
+				182CA8AF5AD16C128ADBB7D6 /* Pods-NimbleMediumTests.debug production.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -927,8 +939,6 @@
 			dependencies = (
 			);
 			name = NimbleMedium;
-			packageProductDependencies = (
-			);
 			productName = NimbleMedium;
 			productReference = 2DB2674A26BBEC4300FF05BB /* Nimble Medium.app */;
 			productType = "com.apple.product-type.application";
@@ -1006,8 +1016,6 @@
 				Base,
 			);
 			mainGroup = 2DB2674126BBEC4300FF05BB;
-			packageReferences = (
-			);
 			productRefGroup = 2DB2674B26BBEC4300FF05BB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1123,7 +1131,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "PATH_TO_GOOGLE_PLISTS=\"$SRCROOT/$PROJECT_NAME/Configurations/Plists/GoogleService\"\n\ncase \"${CONFIGURATION}\" in\n  \"Staging\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Staging/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  \"Production\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Production/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  *)\n    ;;\nesac\n";
+			shellScript = "PATH_TO_GOOGLE_PLISTS=\"$SRCROOT/$PROJECT_NAME/Configurations/Plists/GoogleService\"\n\ncase \"${CONFIGURATION}\" in\n  \"Staging\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Staging/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  \"Debug Staging\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Staging/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  \"Debug Production\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Production/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  \"Production\" )\n    cp -r \"$PATH_TO_GOOGLE_PLISTS/Production/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n    ;;\n  *)\n    ;;\nesac\n";
 		};
 		2DB726B726C117D500C16716 /* R.swift */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1343,138 +1351,7 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		2DB2676E26BBEC4500FF05BB /* Production */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				MTL_FAST_MATH = YES;
-				PRODUCT_NAME = "Nimble Medium";
-				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = PRODUCTION;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Production;
-		};
-		2DB2677126BBEC4500FF05BB /* Production */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E41E63B326C526EFD5BA685 /* Pods-NimbleMedium.production.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_ASSET_PATHS = "\"NimbleMedium/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 4TWS7E2EPE;
-				ENABLE_PREVIEWS = YES;
-				INFOPLIST_FILE = NimbleMedium/Configurations/Plists/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "co.nimblehq.nimble-medium";
-				PRODUCT_MODULE_NAME = NimbleMedium;
-				PRODUCT_NAME = "Nimble Medium";
-				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc co.nimblehq.nimble-medium";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Production;
-		};
-		2DB2677426BBEC4500FF05BB /* Production */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 664F4E0BC9D9E468E0506C22 /* Pods-NimbleMediumTests.production.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 4TWS7E2EPE;
-				INFOPLIST_FILE = NimbleMediumTests/Configurations/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.NimbleMediumTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium.app/Nimble Medium";
-			};
-			name = Production;
-		};
-		2DB2677726BBEC4500FF05BB /* Production */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B350D67E0CE0AD97820184FA /* Pods-NimbleMedium-NimbleMediumUITests.production.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 4TWS7E2EPE;
-				INFOPLIST_FILE = NimbleMediumUITests/Configurations/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.NimbleMediumUITests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = NimbleMedium;
-			};
-			name = Production;
-		};
-		2DB2677826BBEE9D00FF05BB /* Staging */ = {
+		24C9393E26D8D21200547800 /* Staging */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1536,7 +1413,7 @@
 			};
 			name = Staging;
 		};
-		2DB2677926BBEE9D00FF05BB /* Staging */ = {
+		24C9393F26D8D21200547800 /* Staging */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1FB4ECE354F839DF02D6976B /* Pods-NimbleMedium.staging.xcconfig */;
 			buildSettings = {
@@ -1565,7 +1442,7 @@
 			};
 			name = Staging;
 		};
-		2DB2677A26BBEE9D00FF05BB /* Staging */ = {
+		24C9394026D8D21200547800 /* Staging */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 21851292A064EB97674233A2 /* Pods-NimbleMediumTests.staging.xcconfig */;
 			buildSettings = {
@@ -1591,7 +1468,7 @@
 			};
 			name = Staging;
 		};
-		2DB2677B26BBEE9D00FF05BB /* Staging */ = {
+		24C9394126D8D21200547800 /* Staging */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A7FB373E4466876E4BD8212F /* Pods-NimbleMedium-NimbleMediumUITests.staging.xcconfig */;
 			buildSettings = {
@@ -1615,14 +1492,419 @@
 			};
 			name = Staging;
 		};
+		24C9394226D8D22000547800 /* Production */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "Nimble Medium";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = PRODUCTION;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Production;
+		};
+		24C9394326D8D22000547800 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6E41E63B326C526EFD5BA685 /* Pods-NimbleMedium.production.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_ASSET_PATHS = "\"NimbleMedium/Resources/Preview Content\"";
+				DEVELOPMENT_TEAM = 4TWS7E2EPE;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = NimbleMedium/Configurations/Plists/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "co.nimblehq.nimble-medium";
+				PRODUCT_MODULE_NAME = NimbleMedium;
+				PRODUCT_NAME = "Nimble Medium";
+				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc co.nimblehq.nimble-medium";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Production;
+		};
+		24C9394426D8D22000547800 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 664F4E0BC9D9E468E0506C22 /* Pods-NimbleMediumTests.production.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 4TWS7E2EPE;
+				INFOPLIST_FILE = NimbleMediumTests/Configurations/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.NimbleMediumTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium.app/Nimble Medium";
+			};
+			name = Production;
+		};
+		24C9394526D8D22000547800 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B350D67E0CE0AD97820184FA /* Pods-NimbleMedium-NimbleMediumUITests.production.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 4TWS7E2EPE;
+				INFOPLIST_FILE = NimbleMediumUITests/Configurations/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.NimbleMediumUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = NimbleMedium;
+			};
+			name = Production;
+		};
+		2DB2676E26BBEC4500FF05BB /* Debug Production */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "Nimble Medium";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = PRODUCTION;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Debug Production";
+		};
+		2DB2677126BBEC4500FF05BB /* Debug Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 74B1A182D909036C2150D5D4 /* Pods-NimbleMedium.debug production.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"NimbleMedium/Resources/Preview Content\"";
+				DEVELOPMENT_TEAM = 4TWS7E2EPE;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = NimbleMedium/Configurations/Plists/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "co.nimblehq.nimble-medium";
+				PRODUCT_MODULE_NAME = NimbleMedium;
+				PRODUCT_NAME = "Nimble Medium";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Debug Production";
+		};
+		2DB2677426BBEC4500FF05BB /* Debug Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 182CA8AF5AD16C128ADBB7D6 /* Pods-NimbleMediumTests.debug production.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 4TWS7E2EPE;
+				INFOPLIST_FILE = NimbleMediumTests/Configurations/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.NimbleMediumTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium.app/Nimble Medium";
+			};
+			name = "Debug Production";
+		};
+		2DB2677726BBEC4500FF05BB /* Debug Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F8C7D82B80C1CA5F14A914F4 /* Pods-NimbleMedium-NimbleMediumUITests.debug production.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 4TWS7E2EPE;
+				INFOPLIST_FILE = NimbleMediumUITests/Configurations/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.NimbleMediumUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = NimbleMedium;
+			};
+			name = "Debug Production";
+		};
+		2DB2677826BBEE9D00FF05BB /* Debug Staging */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "Nimble Medium - stag";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG STAGING";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = "Debug Staging";
+		};
+		2DB2677926BBEE9D00FF05BB /* Debug Staging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44CDBEC74AB6205DBE05C61C /* Pods-NimbleMedium.debug staging.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_ASSET_PATHS = "\"NimbleMedium/Resources/Preview Content\"";
+				DEVELOPMENT_TEAM = 4TWS7E2EPE;
+				ENABLE_BITCODE = NO;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = NimbleMedium/Configurations/Plists/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "co.nimblehq.nimble-medium-stag";
+				PRODUCT_MODULE_NAME = NimbleMedium;
+				PRODUCT_NAME = "Nimble Medium";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Debug Staging";
+		};
+		2DB2677A26BBEE9D00FF05BB /* Debug Staging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6FED2492E982E731BBE5E9E3 /* Pods-NimbleMediumTests.debug staging.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				"BUNDLE_LOADER[arch=*]" = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 4TWS7E2EPE;
+				INFOPLIST_FILE = NimbleMediumTests/Configurations/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.NimbleMediumTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium.app/Nimble Medium";
+			};
+			name = "Debug Staging";
+		};
+		2DB2677B26BBEE9D00FF05BB /* Debug Staging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 458DD8FDDDFB794337C4FC53 /* Pods-NimbleMedium-NimbleMediumUITests.debug staging.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 4TWS7E2EPE;
+				INFOPLIST_FILE = NimbleMediumUITests/Configurations/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.NimbleMediumUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = NimbleMedium;
+			};
+			name = "Debug Staging";
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
 		2DB2674526BBEC4300FF05BB /* Build configuration list for PBXProject "NimbleMedium" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2DB2677826BBEE9D00FF05BB /* Staging */,
-				2DB2676E26BBEC4500FF05BB /* Production */,
+				2DB2677826BBEE9D00FF05BB /* Debug Staging */,
+				24C9393E26D8D21200547800 /* Staging */,
+				2DB2676E26BBEC4500FF05BB /* Debug Production */,
+				24C9394226D8D22000547800 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
@@ -1630,8 +1912,10 @@
 		2DB2676F26BBEC4500FF05BB /* Build configuration list for PBXNativeTarget "NimbleMedium" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2DB2677926BBEE9D00FF05BB /* Staging */,
-				2DB2677126BBEC4500FF05BB /* Production */,
+				2DB2677926BBEE9D00FF05BB /* Debug Staging */,
+				24C9393F26D8D21200547800 /* Staging */,
+				2DB2677126BBEC4500FF05BB /* Debug Production */,
+				24C9394326D8D22000547800 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
@@ -1639,8 +1923,10 @@
 		2DB2677226BBEC4500FF05BB /* Build configuration list for PBXNativeTarget "NimbleMediumTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2DB2677A26BBEE9D00FF05BB /* Staging */,
-				2DB2677426BBEC4500FF05BB /* Production */,
+				2DB2677A26BBEE9D00FF05BB /* Debug Staging */,
+				24C9394026D8D21200547800 /* Staging */,
+				2DB2677426BBEC4500FF05BB /* Debug Production */,
+				24C9394426D8D22000547800 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
@@ -1648,8 +1934,10 @@
 		2DB2677526BBEC4500FF05BB /* Build configuration list for PBXNativeTarget "NimbleMediumUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2DB2677B26BBEE9D00FF05BB /* Staging */,
-				2DB2677726BBEC4500FF05BB /* Production */,
+				2DB2677B26BBEE9D00FF05BB /* Debug Staging */,
+				24C9394126D8D21200547800 /* Staging */,
+				2DB2677726BBEC4500FF05BB /* Debug Production */,
+				24C9394526D8D22000547800 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;

--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -137,7 +137,7 @@
 		2DA4ABC026CF91E200CF7D68 /* App+Firebase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App+Firebase.swift"; sourceTree = "<group>"; };
 		2DB04AD626C3A4AC003E65F4 /* Color+UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Color+UIColor.swift"; sourceTree = "<group>"; };
 		2DB04AD826C3A6F8003E65F4 /* NimbleMediumUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleMediumUITests.swift; sourceTree = "<group>"; };
-		2DB2674A26BBEC4300FF05BB /* Nimble Medium.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Nimble Medium.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2DB2674A26BBEC4300FF05BB /* Nimble Medium - Staging.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Nimble Medium - Staging.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2DB2674D26BBEC4300FF05BB /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		2DB2675126BBEC4400FF05BB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2DB2675426BBEC4400FF05BB /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -770,7 +770,7 @@
 		2DB2674B26BBEC4300FF05BB /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				2DB2674A26BBEC4300FF05BB /* Nimble Medium.app */,
+				2DB2674A26BBEC4300FF05BB /* Nimble Medium - Staging.app */,
 				2DB2675B26BBEC4500FF05BB /* NimbleMediumTests.xctest */,
 				2DB2676626BBEC4500FF05BB /* NimbleMediumUITests.xctest */,
 			);
@@ -952,7 +952,7 @@
 			);
 			name = NimbleMedium;
 			productName = NimbleMedium;
-			productReference = 2DB2674A26BBEC4300FF05BB /* Nimble Medium.app */;
+			productReference = 2DB2674A26BBEC4300FF05BB /* Nimble Medium - Staging.app */;
 			productType = "com.apple.product-type.application";
 		};
 		2DB2675A26BBEC4500FF05BB /* NimbleMediumTests */ = {
@@ -1159,7 +1159,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$SRCROOT/$PROJECT_NAME/Sources/Supports/Helpers/R.generated.swift",
+				$SRCROOT/$PROJECT_NAME/Sources/Supports/Helpers/R.generated.swift,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1447,7 +1447,7 @@
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "co.nimblehq.nimble-medium-stag";
 				PRODUCT_MODULE_NAME = NimbleMedium;
-				PRODUCT_NAME = "Nimble Medium";
+				PRODUCT_NAME = "Nimble Medium - Staging";
 				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc co.nimblehq.nimble-medium-stag";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1476,7 +1476,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium.app/Nimble Medium";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium - Staging.app/Nimble Medium - Staging";
 			};
 			name = "Release Staging";
 		};
@@ -1608,7 +1608,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium.app/Nimble Medium";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium - Staging.app/Nimble Medium - Staging";
 			};
 			name = "Release Production";
 		};
@@ -1739,7 +1739,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium.app/Nimble Medium";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium - Staging.app/Nimble Medium - Staging";
 			};
 			name = "Debug Production";
 		};
@@ -1850,7 +1850,7 @@
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "co.nimblehq.nimble-medium-stag";
 				PRODUCT_MODULE_NAME = NimbleMedium;
-				PRODUCT_NAME = "Nimble Medium";
+				PRODUCT_NAME = "Nimble Medium - Staging";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1879,7 +1879,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium.app/Nimble Medium";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nimble Medium - Staging.app/Nimble Medium - Staging";
 			};
 			name = "Debug Staging";
 		};

--- a/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium Staging.xcscheme
+++ b/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium Staging.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Staging"
+      buildConfiguration = "Debug Staging"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -51,7 +51,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Staging"
+      buildConfiguration = "Debug Staging"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -72,7 +72,7 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Staging"
+      buildConfiguration = "Debug Staging"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -89,7 +89,7 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Staging">
+      buildConfiguration = "Debug Staging">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Staging"

--- a/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium Staging.xcscheme
+++ b/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium Staging.xcscheme
@@ -92,7 +92,7 @@
       buildConfiguration = "Debug Staging">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Staging"
+      buildConfiguration = "Release Staging"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium Staging.xcscheme
+++ b/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium Staging.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "2DB2674926BBEC4300FF05BB"
-               BuildableName = "Nimble Medium.app"
+               BuildableName = "Nimble Medium - Staging.app"
                BlueprintName = "NimbleMedium"
                ReferencedContainer = "container:NimbleMedium.xcodeproj">
             </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2DB2674926BBEC4300FF05BB"
-            BuildableName = "Nimble Medium.app"
+            BuildableName = "Nimble Medium - Staging.app"
             BlueprintName = "NimbleMedium"
             ReferencedContainer = "container:NimbleMedium.xcodeproj">
          </BuildableReference>
@@ -82,7 +82,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2DB2674926BBEC4300FF05BB"
-            BuildableName = "Nimble Medium.app"
+            BuildableName = "Nimble Medium - Staging.app"
             BlueprintName = "NimbleMedium"
             ReferencedContainer = "container:NimbleMedium.xcodeproj">
          </BuildableReference>

--- a/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium.xcscheme
+++ b/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium.xcscheme
@@ -92,7 +92,7 @@
       buildConfiguration = "Debug Production">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Production"
+      buildConfiguration = "Release Production"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium.xcscheme
+++ b/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Production"
+      buildConfiguration = "Debug Production"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -51,7 +51,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Production"
+      buildConfiguration = "Debug Production"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -72,7 +72,7 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Production"
+      buildConfiguration = "Debug Production"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -89,7 +89,7 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Production">
+      buildConfiguration = "Debug Production">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Production"

--- a/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium.xcscheme
+++ b/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "2DB2674926BBEC4300FF05BB"
-               BuildableName = "Nimble Medium.app"
+               BuildableName = "Nimble Medium - Staging.app"
                BlueprintName = "NimbleMedium"
                ReferencedContainer = "container:NimbleMedium.xcodeproj">
             </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2DB2674926BBEC4300FF05BB"
-            BuildableName = "Nimble Medium.app"
+            BuildableName = "Nimble Medium - Staging.app"
             BlueprintName = "NimbleMedium"
             ReferencedContainer = "container:NimbleMedium.xcodeproj">
          </BuildableReference>
@@ -82,7 +82,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2DB2674926BBEC4300FF05BB"
-            BuildableName = "Nimble Medium.app"
+            BuildableName = "Nimble Medium - Staging.app"
             BlueprintName = "NimbleMedium"
             ReferencedContainer = "container:NimbleMedium.xcodeproj">
          </BuildableReference>

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -84,7 +84,7 @@ PODS:
   - RxSwift (6.2.0)
   - RxTest (6.2.0):
     - RxSwift (= 6.2.0)
-  - Sourcery (1.4.2)
+  - Sourcery (1.5.0)
   - SwiftLint (0.43.1)
   - Wormholy (1.6.4)
 
@@ -165,7 +165,7 @@ SPEC CHECKSUMS:
   RxRelay: e72dbfd157807478401ef1982e1c61c945c94b2f
   RxSwift: d356ab7bee873611322f134c5f9ef379fa183d8f
   RxTest: 0c692fa672b694373ba86d2b00033595297a2831
-  Sourcery: 43d8addc35ca31c2ab331cfd34b02421fa53bb7f
+  Sourcery: eecfeb011c61d150ffc4f306d2fbf52ae89019d5
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   Wormholy: 2e70f64227e010d363f8d33268369f77faf12471
 


### PR DESCRIPTION
## What happened

Add Debug configuration for Staging and Production schemes so that we can still build the application in Debug mode.

## Insight

- [x] Add 2 new Debug configurations for Staging and Production schemes called `Debug Staging` and `Debug Production`.
- [x] Rename 2 existing configurations from `Staging` to `Release Staging` and from `Production` to `Release Production`.
- [x] Update the current schemes to use the new configurations. 
- [x] Update the script for copying Google-Info.plist correct with the 2 new configurations.
- [x] Update app naming to match with to each scheme (Staging, Production).

## Proof Of Work

No visual changes, just under the hood optimization.
