### PR TITLE
[#33] As a user, I can signup for a new account

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		241B4EEA26D3B3F4000409CC /* SideMenuActionItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */; };
 		241B99DC26DF23030041207F /* AutoMockable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B99DB26DF23030041207F /* AutoMockable.generated.swift */; };
+		241B99DE26DF34720041207F /* SignupUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B99DD26DF34720041207F /* SignupUseCase.swift */; };
 		24204C9E26D5289900534314 /* Background.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24204C9D26D5289900534314 /* Background.swift */; };
 		24204CA026D625D300534314 /* SideMenuActionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24204C9F26D625D300534314 /* SideMenuActionsViewModel.swift */; };
 		24204CA226D62B6900534314 /* SideMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24204CA126D62B6900534314 /* SideMenuViewModel.swift */; };
@@ -105,6 +106,7 @@
 		21851292A064EB97674233A2 /* Pods-NimbleMediumTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.staging.xcconfig"; sourceTree = "<group>"; };
 		241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionItemView.swift; sourceTree = "<group>"; };
 		241B99DB26DF23030041207F /* AutoMockable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoMockable.generated.swift; sourceTree = "<group>"; };
+		241B99DD26DF34720041207F /* SignupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupUseCase.swift; sourceTree = "<group>"; };
 		24204C9D26D5289900534314 /* Background.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Background.swift; sourceTree = "<group>"; };
 		24204C9F26D625D300534314 /* SideMenuActionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionsViewModel.swift; sourceTree = "<group>"; };
 		24204CA126D62B6900534314 /* SideMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuViewModel.swift; sourceTree = "<group>"; };
@@ -527,6 +529,7 @@
 			isa = PBXGroup;
 			children = (
 				2459B32726D751E300ABCE61 /* LoginUseCase.swift */,
+				241B99DD26DF34720041207F /* SignupUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -1405,6 +1408,7 @@
 				2D4ADCC426C60940008F8843 /* HomeViewModel.swift in Sources */,
 				2DD4805726D73C67005225CF /* ObservableViewModel.swift in Sources */,
 				24C9393D26D8A26300547800 /* AppMainButton.swift in Sources */,
+				241B99DE26DF34720041207F /* SignupUseCase.swift in Sources */,
 				2497356326D35BBD00177A7C /* MenuOptionButtonStyle.swift in Sources */,
 				2D5485B726C9FAAC00FFE707 /* BehaviorRelayProperty.swift in Sources */,
 				2D7BF28E26DCB4E200A30747 /* Publisher+RxSignal.swift in Sources */,

--- a/NimbleMedium/Sources/Data/NetworkAPI/RequestConfigurations/AuthRequestConfiguration.swift
+++ b/NimbleMedium/Sources/Data/NetworkAPI/RequestConfigurations/AuthRequestConfiguration.swift
@@ -10,6 +10,7 @@ import Alamofire
 enum AuthRequestConfiguration {
 
     case login(email: String, password: String)
+    case signup(username: String, email: String, password: String)
 }
 
 extension AuthRequestConfiguration: RequestConfiguration {
@@ -20,12 +21,14 @@ extension AuthRequestConfiguration: RequestConfiguration {
         switch self {
         case .login:
             return "/users/login"
+        case .signup:
+            return "/users"
         }
     }
 
     var method: HTTPMethod {
         switch self {
-        case .login:
+        case .login, .signup:
             return .post
         }
     }
@@ -35,6 +38,14 @@ extension AuthRequestConfiguration: RequestConfiguration {
         case .login(let email, let password):
             return [
                 "user": [
+                    "email": email,
+                    "password": password
+                ]
+            ]
+        case .signup(let username, let email, let password):
+            return [
+                "user": [
+                    "username": username,
                     "email": email,
                     "password": password
                 ]

--- a/NimbleMedium/Sources/Data/Repositories/Auth/AuthRepository.swift
+++ b/NimbleMedium/Sources/Data/Repositories/Auth/AuthRepository.swift
@@ -21,4 +21,11 @@ final class AuthRepository: AuthRepositoryProtocol {
             .performRequest(requestConfiguration, for: APIUserResponse.self)
             .map { $0.user as User }
     }
+
+    func signup(username: String, email: String, password: String) -> Single<User> {
+        let requestConfiguration = AuthRequestConfiguration.signup(username: username, email: email, password: password)
+        return networkAPI
+            .performRequest(requestConfiguration, for: APIUserResponse.self)
+            .map { $0.user as User }
+    }
 }

--- a/NimbleMedium/Sources/Domain/Repositories/Auth/AuthRepositoryProtocol.swift
+++ b/NimbleMedium/Sources/Domain/Repositories/Auth/AuthRepositoryProtocol.swift
@@ -10,4 +10,6 @@ import RxSwift
 protocol AuthRepositoryProtocol: AnyObject {
 
     func login(email: String, password: String) -> Single<User>
+
+    func signup(username: String, email: String, password: String) -> Single<User>
 }

--- a/NimbleMedium/Sources/Domain/UseCases/SignupUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/SignupUseCase.swift
@@ -1,0 +1,38 @@
+//
+//  SignupUseCase.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 01/09/2021.
+//
+
+import RxSwift
+
+protocol SignupUseCaseProtocol: AnyObject {
+
+    func signup(username: String, email: String, password: String) -> Completable
+}
+
+final class SignupUseCase: SignupUseCaseProtocol {
+
+    private let authRepository: AuthRepositoryProtocol
+    private let userSessionRepository: UserSessionRepositoryProtocol
+
+    init(
+        authRepository: AuthRepositoryProtocol,
+        userSessionRepository: UserSessionRepositoryProtocol
+    ) {
+        self.authRepository = authRepository
+        self.userSessionRepository = userSessionRepository
+    }
+
+    func signup(username: String, email: String, password: String) -> Completable {
+        authRepository
+            .signup(username: username, email: email, password: password)
+            .asObservable()
+            .withUnretained(self)
+            .flatMapLatest { owner, user -> Completable in
+                owner.userSessionRepository.saveUser(user)
+            }
+            .asCompletable()
+    }
+}

--- a/NimbleMedium/Sources/Factories/Application/DependencyFactory+UseCaseFactoryProtocol.swift
+++ b/NimbleMedium/Sources/Factories/Application/DependencyFactory+UseCaseFactoryProtocol.swift
@@ -12,4 +12,10 @@ extension DependencyFactory: UseCaseFactoryProtocol {
             authRepository: authRepository(),
             userSessionRepository: userSessionRepository())
     }
+
+    func signupUseCase() -> SignupUseCaseProtocol {
+        SignupUseCase(
+            authRepository: authRepository(),
+            userSessionRepository: userSessionRepository())
+    }
 }

--- a/NimbleMedium/Sources/Factories/Domain/UseCaseFactoryProtocol.swift
+++ b/NimbleMedium/Sources/Factories/Domain/UseCaseFactoryProtocol.swift
@@ -8,4 +8,6 @@
 protocol UseCaseFactoryProtocol {
 
     func loginUseCase() -> LoginUseCaseProtocol
+
+    func signupUseCase() -> SignupUseCaseProtocol
 }


### PR DESCRIPTION
Resolved #33

## What happened

The users will be able to create a new account by using the signup API from server.

## Insight

- [x] Implement the API for registering a new user via this [endpoint](https://github.com/gothinkster/realworld/tree/master/api#registration).
- [x] Need to provide the new user data in the request body. Here is a sample request body:
```
{
  "user":{
    "username": "Jacob",
    "email": "jake@jake.jake",
    "password": "jakejake"
  }
}
````
- [x] Create a usecase for registering a new user for later usage in integrate task.
- [x] Parse the response into the corresponding model, here is an example response for a registered user:
```
{
  "user": {
    "email": "jake@jake.jake",
    "token": "jwt.token.here",
    "username": "jake",
    "bio": "I work at statefarm",
    "image": null
  }
}
```

## Proof Of Work

https://user-images.githubusercontent.com/70877098/131612980-9e990454-13c9-4f36-811d-c429b760dc7e.mov


Full success request/response log:
```
---------------------
POST 'https://conduit.productionready.io/api/users':
cURL:
$ curl -v \
	-X POST \
	-H "Accept-Encoding: br;q=1.0, gzip;q=0.9, deflate;q=0.8" \
	-H "User-Agent: Nimble Medium - Staging/1.0.0 (co.nimblehq.nimble-medium-stag; build:1; iOS 14.7.1) Alamofire/5.4.3" \
	-H "Accept-Language: en-VN;q=1.0, vi-VN;q=0.9, th-VN;q=0.8" \
	-H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
	-d "user%5Bpassword%5D=12345678&user%5Bemail%5D=test1%40nimblehq.co&user%5Busername%5D=Nimble%20Test1" \
	"https://conduit.productionready.io/api/users"
2021-09-01 11:35:37.011175+0700 Nimble Medium - Staging[2085:1574962] [connection] nw_endpoint_handler_set_adaptive_read_handler [C3.1 2606:4700:3033::6815:3697.443 ready channel-flow (satisfied (Path is satisfied), viable, interface: en0, ipv4, ipv6, dns)] unregister notification for read_timeout failed
2021-09-01 11:35:37.011273+0700 Nimble Medium - Staging[2085:1574962] [connection] nw_endpoint_handler_set_adaptive_write_handler [C3.1 2606:4700:3033::6815:3697.443 ready channel-flow (satisfied (Path is satisfied), viable, interface: en0, ipv4, ipv6, dns)] unregister notification for write_timeout failed
---------------------
200 'https://conduit.productionready.io/api/users' [0.8936 s]:
Headers: [
  Location: /
  x-runtime: 0.136889
  Server: cloudflare
  report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Ogl2NGZziOzkXOOV%2BPHLh%2BtAOKxMJ1YiG1mMTaoch1Mah8AAyaLoWUHGBJ8A8Q2UxqkhqAa7hdYTbwdCxeky5pTUARS6LgJGjn5w8Nw4yAA%2FQyrM9PN9GB0UIotaX1IHqlD%2FjUtPZx6Nag9CGoioAPYXMcPF%2BOedRQ%3D%3D"}],"group":"cf-nel","max_age":604800}
  Content-Type: application/json; charset=utf-8
  x-frame-options: SAMEORIGIN
  Date: Wed, 01 Sep 2021 04:35:37 GMT
  x-xss-protection: 1; mode=block
  x-powered-by: Phusion Passenger 4.0.60
  Etag: W/"63662ba23a3a1eb43060e8e6004147f7"
  Content-Encoding: br
  nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
  x-request-id: 13c898d7-3403-4865-80da-0a9122829348
  cf-ray: 687bcafd6a5e4a89-SIN
  cf-cache-status: DYNAMIC
  Alt-Svc: h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400
  x-content-type-options: nosniff
  Vary: Origin
  expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
  Status: 200 OK
  Cache-Control: max-age=0, private, must-revalidate
]
Body:
{
  "user" : {
    "id" : 217663,
    "bio" : null,
    "image" : null,
    "email" : "test1@nimblehq.co",
    "updatedAt" : "2021-09-01T04:35:37.678Z",
    "createdAt" : "2021-09-01T04:35:37.662Z",
    "username" : "Nimble Test1",
    "token" : "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MjE3NjYzLCJ1c2VybmFtZSI6Ik5pbWJsZSBUZXN0MSIsImV4cCI6MTYzNTY1NDkzN30.QmtI1qdlhMHfNvTJry8Y502hcJ2eAxoNORcNMr7xdQo"
  }
}
```
