### PR TITLE
[#31] As a user, I can signup for a new account

### DIFF
--- a/NimbleMedium/Resources/en.lproj/Localizable.strings
+++ b/NimbleMedium/Resources/en.lproj/Localizable.strings
@@ -15,7 +15,7 @@
 
 "login.title" = "Login";
 "login.textFieldEmail.placeholder" = "Email";
-"login.textfieldPassword.placeholder" = "Password";
+"login.textFieldPassword.placeholder" = "Password";
 "login.needAccount.title" = "Need an account?";
 
 "menu.header.description" = "A place to share your knowledge";

--- a/NimbleMedium/Sources/Factories/Application/DependencyFactory+ViewModelFactoryProtocol.swift
+++ b/NimbleMedium/Sources/Factories/Application/DependencyFactory+ViewModelFactoryProtocol.swift
@@ -28,6 +28,6 @@ extension DependencyFactory: ViewModelFactoryProtocol {
     }
 
     func signupViewModel() -> SignupViewModelProtocol {
-        SignupViewModel()
+        SignupViewModel(factory: self)
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
@@ -13,10 +13,10 @@ struct LoginView: View {
     @Environment(\.presentationMode) var presentationMode
 
     @State private var email = ""
-    @State private var password = ""
-    @State private var loadingToast: Bool = false
-    @State private var errorToast: Bool = false
     @State private var errorMessage = ""
+    @State private var password = ""
+    @State private var errorToast = false
+    @State private var loadingToast = false
 
     @ObservedViewModel var viewModel: LoginViewModelProtocol
 
@@ -58,7 +58,7 @@ struct LoginView: View {
                     supportEmailKeyboard: true
                 )
                 AuthSecureFieldView(
-                    placeholder: Localizable.loginTextfieldPasswordPlaceholder(),
+                    placeholder: Localizable.loginTextFieldPasswordPlaceholder(),
                     text: $password)
                 AppMainButton(title: Localizable.actionLogin()) {
                     hideKeyboard()

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
@@ -21,7 +21,22 @@ struct LoginView: View {
     @ObservedViewModel var viewModel: LoginViewModelProtocol
 
     var body: some View {
-        NavigationView { navBackgroundContent }
+        NavigationView {
+            contentView
+                .onTapGesture { hideKeyboard() }
+                .navigationBarTitle(Localizable.loginTitle(), displayMode: .inline)
+                .navigationBarColor(backgroundColor: .green)
+                .toolbar { navigationBarLeadingContent }
+                .toast(isPresented: $errorToast, dismissAfter: 3.0) {
+                    ToastView(errorMessage) { } background: {
+                        Color.clear
+                    }
+                }
+                .toast(isPresented: $loadingToast) {
+                    ToastView(String.empty) { }
+                        .toastViewStyle(IndefiniteProgressToastViewStyle())
+                }
+        }
         .accentColor(.white)
         .onReceive(viewModel.output.didLogin) { _ in
             presentationMode.wrappedValue.dismiss()
@@ -49,7 +64,7 @@ struct LoginView: View {
     }
 
     // swiftlint:disable closure_body_length
-    var navBackgroundContent: some View {
+    var contentView: some View {
         Background {
             VStack(spacing: 15.0) {
                 AuthTextFieldView(
@@ -77,20 +92,6 @@ struct LoginView: View {
                 .foregroundColor(.green)
             }
             .padding()
-
-        }
-        .onTapGesture { hideKeyboard() }
-        .navigationBarTitle(Localizable.loginTitle(), displayMode: .inline)
-        .navigationBarColor(backgroundColor: .green)
-        .toolbar { navigationBarLeadingContent }
-        .toast(isPresented: $errorToast, dismissAfter: 3.0) {
-            ToastView(errorMessage) { } background: {
-                Color.clear
-            }
-        }
-        .toast(isPresented: $loadingToast) {
-            ToastView(String.empty) { }
-                .toastViewStyle(IndefiniteProgressToastViewStyle())
         }
     }
 

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by Minh Pham on 24/08/2021.
 //
 
-import Combine
 import RxSwift
 import RxCocoa
 

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
@@ -51,6 +51,12 @@ final class SideMenuActionsViewModel: ObservableObject, SideMenuActionsViewModel
                 owner.$didSelectSignupOption.accept(true)
             })
             .disposed(by: disposeBag)
+
+        signupViewModel.output.didSelectHaveAccount.asObservable()
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.$didSelectLoginOption.accept(true)
+            })
+            .disposed(by: disposeBag)
     }
 }
 

--- a/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
@@ -6,54 +6,34 @@
 //
 
 import SwiftUI
+import ToastUI
 
 struct SignupView: View {
 
     @Environment(\.presentationMode) var presentationMode
 
     @State private var email = ""
+    @State private var errorMessage = ""
     @State private var password = ""
     @State private var username = ""
+    @State private var errorToast = false
+    @State private var loadingToast = false
 
     private var viewModel: SignupViewModelProtocol
 
-    // swiftlint:disable closure_body_length
     var body: some View {
-        NavigationView {
-            Background {
-                VStack(spacing: 15.0) {
-                    AuthTextFieldView(
-                        placeholder: Localizable.signupTextFieldUsernamePlaceholder(),
-                        text: $username
-                    )
-                    AuthTextFieldView(
-                        placeholder: Localizable.signupTextFieldEmailPlaceholder(),
-                        text: $email,
-                        supportEmailKeyboard: true
-                    )
-                    AuthSecureFieldView(
-                        placeholder: Localizable.signupTextFieldPasswordPlaceholder(),
-                        text: $password)
-                    AppMainButton(title: Localizable.actionSignup()) {
-                        // TODO: Implement in integrate task
-                    }
-                    Button(
-                        action: {
-                            // TODO: Implement in integrate task
-                        }, label: {
-                            Text(Localizable.signupHaveAccountTitle())
-                                .frame(height: 25.0)
-                        }
-                    )
-                    .foregroundColor(.green)
-                }
-            }
-            .onTapGesture { hideKeyboard() }
-            .navigationBarTitle(Localizable.signupTitle(), displayMode: .inline)
-            .navigationBarColor(backgroundColor: .green)
-            .toolbar { navigationBarLeadingContent }
-        }
+        NavigationView { navBackgroundContent }
         .accentColor(.white)
+        .onReceive(viewModel.output.didSignup) { _ in
+            presentationMode.wrappedValue.dismiss()
+        }
+        .onReceive(viewModel.output.errorMessage) { _ in
+            errorMessage = Localizable.errorGeneric()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { errorToast.toggle() }
+        }
+        .onReceive(viewModel.output.isLoading) {
+            loadingToast = $0
+        }
     }
 
     var navigationBarLeadingContent: some ToolbarContent {
@@ -69,6 +49,56 @@ struct SignupView: View {
         }
     }
 
+    // swiftlint:disable closure_body_length
+    var navBackgroundContent: some View {
+        Background {
+            VStack(spacing: 15.0) {
+                AuthTextFieldView(
+                    placeholder: Localizable.signupTextFieldUsernamePlaceholder(),
+                    text: $username
+                )
+                AuthTextFieldView(
+                    placeholder: Localizable.signupTextFieldEmailPlaceholder(),
+                    text: $email,
+                    supportEmailKeyboard: true
+                )
+                AuthSecureFieldView(
+                    placeholder: Localizable.signupTextFieldPasswordPlaceholder(),
+                    text: $password)
+                AppMainButton(title: Localizable.actionSignup()) {
+                    hideKeyboard()
+                    viewModel.input.didTapSignupButton(username: username, email: email, password: password)
+                }
+                .disabled(username.isEmpty || email.isEmpty || password.isEmpty || loadingToast)
+                Button(
+                    action: {
+                        presentationMode.wrappedValue.dismiss()
+                        viewModel.input.didTapHaveAccountButton()
+                    }, label: {
+                        Text(Localizable.signupHaveAccountTitle())
+                            .frame(height: 25.0)
+                    }
+                )
+                .foregroundColor(.green)
+            }
+            .padding()
+
+        }
+        .onTapGesture { hideKeyboard() }
+        .navigationBarTitle(Localizable.signupTitle(), displayMode: .inline)
+        .navigationBarColor(backgroundColor: .green)
+        .toolbar { navigationBarLeadingContent }
+        .toast(isPresented: $errorToast, dismissAfter: 3.0) {
+            ToastView(errorMessage) { } background: {
+                Color.clear
+            }
+        }
+        .toast(isPresented: $loadingToast) {
+            ToastView(String.empty) { }
+                .toastViewStyle(IndefiniteProgressToastViewStyle())
+        }
+    }
+
     init(viewModel: SignupViewModelProtocol) {
         self.viewModel = viewModel
     }
@@ -77,7 +107,8 @@ struct SignupView: View {
 #if DEBUG
 struct SignupView_Previews: PreviewProvider {
     static var previews: some View {
-        SignupView(viewModel: SignupViewModel())
+        let viewModel = SignupViewModel(factory: App().factory)
+        return SignupView(viewModel: viewModel)
     }
 }
 #endif

--- a/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
@@ -22,7 +22,22 @@ struct SignupView: View {
     private var viewModel: SignupViewModelProtocol
 
     var body: some View {
-        NavigationView { navBackgroundContent }
+        NavigationView {
+            contentView
+                .onTapGesture { hideKeyboard() }
+                .navigationBarTitle(Localizable.signupTitle(), displayMode: .inline)
+                .navigationBarColor(backgroundColor: .green)
+                .toolbar { navigationBarLeadingContent }
+                .toast(isPresented: $errorToast, dismissAfter: 3.0) {
+                    ToastView(errorMessage) { } background: {
+                        Color.clear
+                    }
+                }
+                .toast(isPresented: $loadingToast) {
+                    ToastView(String.empty) { }
+                        .toastViewStyle(IndefiniteProgressToastViewStyle())
+                }
+        }
         .accentColor(.white)
         .onReceive(viewModel.output.didSignup) { _ in
             presentationMode.wrappedValue.dismiss()
@@ -50,7 +65,7 @@ struct SignupView: View {
     }
 
     // swiftlint:disable closure_body_length
-    var navBackgroundContent: some View {
+    var contentView: some View {
         Background {
             VStack(spacing: 15.0) {
                 AuthTextFieldView(
@@ -82,20 +97,6 @@ struct SignupView: View {
                 .foregroundColor(.green)
             }
             .padding()
-
-        }
-        .onTapGesture { hideKeyboard() }
-        .navigationBarTitle(Localizable.signupTitle(), displayMode: .inline)
-        .navigationBarColor(backgroundColor: .green)
-        .toolbar { navigationBarLeadingContent }
-        .toast(isPresented: $errorToast, dismissAfter: 3.0) {
-            ToastView(errorMessage) { } background: {
-                Color.clear
-            }
-        }
-        .toast(isPresented: $loadingToast) {
-            ToastView(String.empty) { }
-                .toastViewStyle(IndefiniteProgressToastViewStyle())
         }
     }
 

--- a/NimbleMedium/Sources/Presentation/Modules/Signup/SignupViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Signup/SignupViewModel.swift
@@ -6,15 +6,20 @@
 //
 
 import RxSwift
+import RxCocoa
 
 protocol SignupViewModelInput {
 
-    // TODO: To be implemented
+    func didTapSignupButton(username: String, email: String, password: String)
+    func didTapHaveAccountButton()
 }
 
 protocol SignupViewModelOutput {
 
-    // TODO: To be implemented
+    var didSignup: Signal<Void> { get }
+    var didSelectHaveAccount: Signal<Void> { get }
+    var errorMessage: Signal<String> { get }
+    var isLoading: Driver<Bool> { get }
 }
 
 protocol SignupViewModelProtocol {
@@ -25,11 +30,47 @@ protocol SignupViewModelProtocol {
 
 final class SignupViewModel: SignupViewModelProtocol {
 
+    private let disposeBag = DisposeBag()
+    private let signupUseCase: SignupUseCaseProtocol
+
     var input: SignupViewModelInput { self }
     var output: SignupViewModelOutput { self }
 
+    @PublishRelayProperty var didSignup: Signal<Void>
+    @PublishRelayProperty var didSelectHaveAccount: Signal<Void>
+    @PublishRelayProperty var errorMessage: Signal<String>
+    @BehaviorRelayProperty(false) var isLoading: Driver<Bool>
+
+    init(factory: ModuleFactoryProtocol) {
+        signupUseCase = factory.signupUseCase()
+    }
+
+    private func signup(username: String, email: String, password: String) {
+        signupUseCase
+            .signup(username: username, email: email, password: password)
+            .subscribe(
+                with: self,
+                onCompleted: { owner in
+                    owner.$isLoading.accept(false)
+                    owner.$didSignup.accept(())
+                }, onError: { owner, error  in
+                    owner.$isLoading.accept(false)
+                    owner.$errorMessage.accept(error.detail)
+                })
+            .disposed(by: disposeBag)
+    }
 }
 
-extension SignupViewModel: SignupViewModelInput { }
+extension SignupViewModel: SignupViewModelInput {
+
+    func didTapSignupButton(username: String, email: String, password: String) {
+        $isLoading.accept(true)
+        signup(username: username, email: email, password: password)
+    }
+
+    func didTapHaveAccountButton() {
+        $didSelectHaveAccount.accept(())
+    }
+}
 
 extension SignupViewModel: SignupViewModelOutput { }


### PR DESCRIPTION
Resolved #31

## What happened

For the new users of the application, they should be able to signup and create a new account for being able to explore and use more features from the application.

## Insight

- [x] Disable the `Sign up` button when there is any empty text field, enable it when all the text fields are not empty.
- [x] When clicking on `Sign up` button, call the API to server for signing up, dismiss the keyboard if it is showing and show a native loading indicator in the middle of the screen while doing so.
- [x] When there is an API error while signing up, show a temporary toast message with text: `Something went wrong. Please try again later.`
- [x] When signing up successfully, dismiss the `Signup` screen and go back to the `Home` screen with the newly registered user as authenticated.
- [x] Store the authenticated user data for later usage throughout the application. **Implemented in #33**

## Proof Of Work

- Request signup - success case:

https://user-images.githubusercontent.com/70877098/131616038-6358746a-d8e8-4e98-be20-67eda8dd481c.mov


- Navigate to Login screen:

https://user-images.githubusercontent.com/70877098/131615959-e3936f26-7206-406e-b14f-651f762b9dac.mov



