### PR TITLE
[#126] Setup Codecov

### DIFF
--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -55,4 +55,14 @@ jobs:
       shell: bash
 
     - name: Build and Test
-      run: xcodebuild -workspace NimbleMedium.xcworkspace -scheme 'NimbleMedium Staging' -destination 'platform=iOS Simulator,name=iPhone 12' clean test | xcpretty && exit ${PIPESTATUS[0]}
+      run: xcodebuild -workspace NimbleMedium.xcworkspace -scheme 'NimbleMedium Staging' -destination 'platform=iOS Simulator,name=iPhone 12' -enableCodeCoverage YES clean build test | xcpretty && exit ${PIPESTATUS[0]}
+
+    - name: Generate code coverage file
+      run: slather
+
+    - name: Upload code coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./cobertura.xml
+        fail_ci_if_error: false
+        verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ Carthage/Build
 
 .env
 *.generated.swift
+/cobertura.xml

--- a/.slather.yml
+++ b/.slather.yml
@@ -1,0 +1,5 @@
+coverage_service: cobertura_xml
+workspace: ./NimbleMedium.xcworkspace
+xcodeproj: ./NimbleMedium.xcodeproj
+scheme: NimbleMedium Staging
+output_directory: ./

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "fastlane"
 gem "cocoapods", "1.10.1"
+gem 'slather'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     claide (1.0.3)
+    clamp (1.3.2)
     cocoapods (1.10.1)
       addressable (~> 2.6)
       claide (>= 1.0.2, < 2.0)
@@ -211,9 +212,12 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
+    nokogiri (1.12.4-x86_64-darwin)
+      racc (~> 1.4)
     os (1.1.1)
     plist (3.6.0)
     public_suffix (4.0.6)
+    racc (1.5.2)
     rake (13.0.6)
     representable (3.1.1)
       declarative (< 0.1.0)
@@ -234,6 +238,12 @@ GEM
     simctl (1.6.8)
       CFPropertyList
       naturally
+    slather (2.7.1)
+      CFPropertyList (>= 2.2, < 4)
+      activesupport
+      clamp (~> 1.3)
+      nokogiri (~> 1.11)
+      xcodeproj (~> 1.7)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -274,6 +284,7 @@ DEPENDENCIES
   cocoapods (= 1.10.1)
   fastlane
   fastlane-plugin-firebase_app_distribution
+  slather
 
 BUNDLED WITH
    2.2.20

--- a/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium Staging.xcscheme
+++ b/NimbleMedium.xcodeproj/xcshareddata/xcschemes/NimbleMedium Staging.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug Staging"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DB2674926BBEC4300FF05BB"
+            BuildableName = "Nimble Medium - Staging.app"
+            BlueprintName = "NimbleMedium"
+            ReferencedContainer = "container:NimbleMedium.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
Resolved #126 

## What happened

Setup Codecov

## Insight

- Use `slasher` to convert code coverage data to xml
- Upload converted xml to Codecov
- 

## Proof Of Work

<img width="944" alt="Screen Shot 2021-09-08 at 10 05 04" src="https://user-images.githubusercontent.com/17875522/132439840-66a0f8f5-635e-442b-8d9d-52812a65941c.png">

