### PR TITLE
[#105] [#28] As a user, I can see the list of comments of an article

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		2D17E4F426F07ABA001D3F90 /* View+If.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D17E4F326F07ABA001D3F90 /* View+If.swift */; };
 		2D1D727426EB305F00431679 /* DateFormatter+Formats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1D727326EB305F00431679 /* DateFormatter+Formats.swift */; };
 		2D1D727826EB37BD00431679 /* articles.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D1D727726EB37BD00431679 /* articles.json */; };
+		2D29A70A26F43CB6001EA24F /* FeedCommentsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D29A70926F43CB6001EA24F /* FeedCommentsViewModel.swift */; };
+		2D29A70D26F44426001EA24F /* FeedCommentsViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D29A70C26F44426001EA24F /* FeedCommentsViewModelSpec.swift */; };
 		2D29A70F26F44EBC001EA24F /* FeedRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D29A70E26F44EBC001EA24F /* FeedRowViewModel.swift */; };
 		2D2F456026C25911002C0331 /* View+NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D2F455F26C25911002C0331 /* View+NavigationBar.swift */; };
 		2D303B3B26C28AC200EEF1C0 /* Constants+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D303B3A26C28AC200EEF1C0 /* Constants+String.swift */; };
@@ -71,6 +73,9 @@
 		2D46FAF526F87B5D005DD323 /* Expectation+TestableObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D46FAF426F87B5D005DD323 /* Expectation+TestableObserver.swift */; };
 		2D4ADCC426C60940008F8843 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4ADCC326C60940008F8843 /* HomeViewModel.swift */; };
 		2D4ADCC926C61192008F8843 /* FeedsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4ADCC826C61192008F8843 /* FeedsViewModel.swift */; };
+		2D4BB30126FC5923005FED5F /* FeedCommentRow+UIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4BB30026FC5923005FED5F /* FeedCommentRow+UIModel.swift */; };
+		2D4BB30326FC5930005FED5F /* FeedCommentRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4BB30226FC5930005FED5F /* FeedCommentRowViewModel.swift */; };
+		2D4BB30626FC77B2005FED5F /* FeedCommentRowViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4BB30526FC77B2005FED5F /* FeedCommentRowViewModelSpec.swift */; };
 		2D5485B726C9FAAC00FFE707 /* BehaviorRelayProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5485B626C9FAAC00FFE707 /* BehaviorRelayProperty.swift */; };
 		2D5485BC26CA077600FFE707 /* View+OnReceive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5485BB26CA077600FFE707 /* View+OnReceive.swift */; };
 		2D5485BE26CA0D2C00FFE707 /* PublishRelayProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5485BD26CA0D2C00FFE707 /* PublishRelayProperty.swift */; };
@@ -214,6 +219,8 @@
 		2D17E4F326F07ABA001D3F90 /* View+If.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+If.swift"; sourceTree = "<group>"; };
 		2D1D727326EB305F00431679 /* DateFormatter+Formats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Formats.swift"; sourceTree = "<group>"; };
 		2D1D727726EB37BD00431679 /* articles.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = articles.json; sourceTree = "<group>"; };
+		2D29A70926F43CB6001EA24F /* FeedCommentsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCommentsViewModel.swift; sourceTree = "<group>"; };
+		2D29A70C26F44426001EA24F /* FeedCommentsViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCommentsViewModelSpec.swift; sourceTree = "<group>"; };
 		2D29A70E26F44EBC001EA24F /* FeedRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedRowViewModel.swift; sourceTree = "<group>"; };
 		2D2F455F26C25911002C0331 /* View+NavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+NavigationBar.swift"; sourceTree = "<group>"; };
 		2D303B3A26C28AC200EEF1C0 /* Constants+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Constants+String.swift"; sourceTree = "<group>"; };
@@ -224,6 +231,9 @@
 		2D46FAF426F87B5D005DD323 /* Expectation+TestableObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Expectation+TestableObserver.swift"; sourceTree = "<group>"; };
 		2D4ADCC326C60940008F8843 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		2D4ADCC826C61192008F8843 /* FeedsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedsViewModel.swift; sourceTree = "<group>"; };
+		2D4BB30026FC5923005FED5F /* FeedCommentRow+UIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedCommentRow+UIModel.swift"; sourceTree = "<group>"; };
+		2D4BB30226FC5930005FED5F /* FeedCommentRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCommentRowViewModel.swift; sourceTree = "<group>"; };
+		2D4BB30526FC77B2005FED5F /* FeedCommentRowViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCommentRowViewModelSpec.swift; sourceTree = "<group>"; };
 		2D5485B626C9FAAC00FFE707 /* BehaviorRelayProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BehaviorRelayProperty.swift; sourceTree = "<group>"; };
 		2D5485BB26CA077600FFE707 /* View+OnReceive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+OnReceive.swift"; sourceTree = "<group>"; };
 		2D5485BD26CA0D2C00FFE707 /* PublishRelayProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishRelayProperty.swift; sourceTree = "<group>"; };
@@ -555,6 +565,15 @@
 			path = JSON;
 			sourceTree = "<group>";
 		};
+		2D29A70B26F44415001EA24F /* FeedComments */ = {
+			isa = PBXGroup;
+			children = (
+				2D4BB30426FC779F005FED5F /* FeedCommentRow */,
+				2D29A70C26F44426001EA24F /* FeedCommentsViewModelSpec.swift */,
+			);
+			path = FeedComments;
+			sourceTree = "<group>";
+		};
 		2D303B3C26C28AE900EEF1C0 /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
@@ -604,6 +623,14 @@
 				2D46FAF226F8618D005DD323 /* FeedRowViewModelSpec.swift */,
 			);
 			path = FeedRow;
+			sourceTree = "<group>";
+		};
+		2D4BB30426FC779F005FED5F /* FeedCommentRow */ = {
+			isa = PBXGroup;
+			children = (
+				2D4BB30526FC77B2005FED5F /* FeedCommentRowViewModelSpec.swift */,
+			);
+			path = FeedCommentRow;
 			sourceTree = "<group>";
 		};
 		2D5485B526C9FA9A00FFE707 /* Rx */ = {
@@ -878,6 +905,7 @@
 		2D72E49526C21C3B00861239 /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				2D29A70B26F44415001EA24F /* FeedComments */,
 				2DB31D4F26F1960B007254B9 /* FeedDetail */,
 				2D79A8FA26EF4A70007B81D1 /* Feeds */,
 				24F3D7BC26DE041F00DE2420 /* Login */,
@@ -1033,6 +1061,7 @@
 			children = (
 				2D882EEA26F1D46300DB6560 /* FeedCommentRow */,
 				2D882EE826F1D3BD00DB6560 /* FeedCommentsView.swift */,
+				2D29A70926F43CB6001EA24F /* FeedCommentsViewModel.swift */,
 			);
 			path = FeedComments;
 			sourceTree = "<group>";
@@ -1041,6 +1070,8 @@
 			isa = PBXGroup;
 			children = (
 				2D882EEB26F1D47300DB6560 /* FeedCommentRow.swift */,
+				2D4BB30026FC5923005FED5F /* FeedCommentRow+UIModel.swift */,
+				2D4BB30226FC5930005FED5F /* FeedCommentRowViewModel.swift */,
 			);
 			path = FeedCommentRow;
 			sourceTree = "<group>";
@@ -1698,6 +1729,7 @@
 				249042EA26D4D61300E970B6 /* View+UIResponder.swift in Sources */,
 				2459B31F26D7503A00ABCE61 /* AuthRepository.swift in Sources */,
 				2D55E4A726DF231700161052 /* Article.swift in Sources */,
+				2D4BB30326FC5930005FED5F /* FeedCommentRowViewModel.swift in Sources */,
 				2DE8C09226F97386006061B4 /* FeedRow+UIModel.swift in Sources */,
 				2DEF1F9026E5FE8E00EB93CC /* ArticleRepositoryProtocol.swift in Sources */,
 				2D55E4AE26DF2FA800161052 /* FeedRow.swift in Sources */,
@@ -1706,6 +1738,7 @@
 				2D303B3B26C28AC200EEF1C0 /* Constants+String.swift in Sources */,
 				24204CA226D62B6900534314 /* SideMenuViewModel.swift in Sources */,
 				2D882ED726F1CB6600DB6560 /* ArticleCommentRepository.swift in Sources */,
+				2D4BB30126FC5923005FED5F /* FeedCommentRow+UIModel.swift in Sources */,
 				24C9393B26D8A1A200547800 /* AuthSecureFieldView.swift in Sources */,
 				246B387626F8A6AA003173FD /* SideMenuHeaderView+UIModel.swift in Sources */,
 				249042E726D4D14F00E970B6 /* SignupViewModel.swift in Sources */,
@@ -1785,6 +1818,7 @@
 				2DD4805826D73C67005225CF /* ObservedViewModel.swift in Sources */,
 				24F3D7AC26DCE84A00DE2420 /* Keychain.swift in Sources */,
 				2D4ADCC926C61192008F8843 /* FeedsViewModel.swift in Sources */,
+				2D29A70A26F43CB6001EA24F /* FeedCommentsViewModel.swift in Sources */,
 				2424B22F26D4A2EF00CF07B5 /* LoginViewModel.swift in Sources */,
 				2DE3B9B526C1339200272775 /* Typealias.swift in Sources */,
 				2459B31126D74B3100ABCE61 /* JSONDecoder+Default.swift in Sources */,
@@ -1800,10 +1834,12 @@
 				2D73312F26F0F3A20052DCC7 /* APIArticleResponse+Dummy.swift in Sources */,
 				2D73313126F0F4800052DCC7 /* GetArticleUseCaseSpec.swift in Sources */,
 				2D79A8FC26EF4A7E007B81D1 /* FeedsViewModelSpec.swift in Sources */,
+				2D29A70D26F44426001EA24F /* FeedCommentsViewModelSpec.swift in Sources */,
 				24F3D7C426DE0FAE00DE2420 /* TestError.swift in Sources */,
 				246B387926F8A7D7003173FD /* SideMenuHeaderViewModelSpec.swift in Sources */,
 				24F3D7BE26DE041F00DE2420 /* LoginViewModelSpec.swift in Sources */,
 				2D882EE626F1CF4600DB6560 /* GetArticleCommentsUseCaseSpec.swift in Sources */,
+				2D4BB30626FC77B2005FED5F /* FeedCommentRowViewModelSpec.swift in Sources */,
 				241B99DC26DF23030041207F /* AutoMockable.generated.swift in Sources */,
 				2DEF1FA726E6181F00EB93CC /* Data+Decode.swift in Sources */,
 				2D46FAF026F830B0005DD323 /* PrimitiveSequenceType+TestScheduler.swift in Sources */,

--- a/NimbleMedium/Resources/en.lproj/Localizable.strings
+++ b/NimbleMedium/Resources/en.lproj/Localizable.strings
@@ -13,18 +13,21 @@
 
 "error.generic" = "Something went wrong.\nPlease try again later.";
 
+"feedComments.noComment.message" = "No Comment";
 "feedComments.title" = "Comments History";
 
+"feedDetail.comments.title" = "Go to comments section";
 "feedDetail.fetchFailure.message" = "Unable to load the article";
 "feedDetail.title" = "Article";
 
 "feeds.comments.title" = "Go to comments section";
 "feeds.noArticle" = "No Article";
+"feeds.title" = "Feeds";
 
-"login.title" = "Login";
+"login.needAccount.title" = "Need an account?";
 "login.textFieldEmail.placeholder" = "Email";
 "login.textFieldPassword.placeholder" = "Password";
-"login.needAccount.title" = "Need an account?";
+"login.title" = "Login";
 
 "menu.header.description" = "A place to share your knowledge";
 "menu.header.title" = "Nimble Medium";
@@ -40,9 +43,3 @@
 "signup.title" = "Signup";
 
 "userProfile.title" = "Profile";
-"feedDetail.title" = "Article";
-"feedDetail.fetchFailure.message" = "Unable to load the article";
-"feedDetail.comments.title" = "Go to comments section";
-
-"feedComments.title" = "Comments History";
-"feedComments.noComment.message" = "No Comment";

--- a/NimbleMedium/Resources/en.lproj/Localizable.strings
+++ b/NimbleMedium/Resources/en.lproj/Localizable.strings
@@ -20,7 +20,6 @@
 
 "feeds.comments.title" = "Go to comments section";
 "feeds.noArticle" = "No Article";
-"feeds.title" = "Feeds";
 
 "login.title" = "Login";
 "login.textFieldEmail.placeholder" = "Email";
@@ -41,3 +40,9 @@
 "signup.title" = "Signup";
 
 "userProfile.title" = "Profile";
+"feedDetail.title" = "Article";
+"feedDetail.fetchFailure.message" = "Unable to load the article";
+"feedDetail.comments.title" = "Go to comments section";
+
+"feedComments.title" = "Comments History";
+"feedComments.noComment.message" = "No Comment";

--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -75,7 +75,13 @@ extension Resolver: ResolverRegistering {
         register { SideMenuViewModel() }.implements(SideMenuViewModelProtocol.self).scope(.cached)
         register { SignupViewModel() }.implements(SignupViewModelProtocol.self).scope(.cached)
         register { _, args in
-            FeedDetailViewModel(slug: args.get())
+            FeedDetailViewModel(id: args.get())
         }.implements(FeedDetailViewModelProtocol.self)
+        register { _, args in
+            FeedCommentsViewModel(id: args.get())
+        }.implements(FeedCommentsViewModelProtocol.self)
+        register { _, args in
+            FeedCommentRowViewModel(comment: args.get())
+        }.implements(FeedCommentRowViewModelProtocol.self)
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/FeedComments/FeedCommentRow/FeedCommentRow+UIModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/FeedComments/FeedCommentRow/FeedCommentRow+UIModel.swift
@@ -1,0 +1,19 @@
+//
+//  FeedCommentRow+UIModel.swift
+//  NimbleMedium
+//
+//  Created by Mark G on 23/09/2021.
+//
+
+import Foundation
+
+extension FeedCommentRow {
+
+    struct UIModel: Equatable {
+
+        let commentBody: String
+        let commentUpdatedAt: String
+        let authorName: String
+        let authorImage: URL?
+    }
+}

--- a/NimbleMedium/Sources/Presentation/Modules/FeedComments/FeedCommentRow/FeedCommentRow.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/FeedComments/FeedCommentRow/FeedCommentRow.swift
@@ -10,30 +10,51 @@ import SDWebImageSwiftUI
 
 struct FeedCommentRow: View {
 
+    @ObservedViewModel private var viewModel: FeedCommentRowViewModelProtocol
+
+    @State var uiModel: UIModel?
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 0.0) {
-            // TODO: Update with real data in Integrate
-            Text("Cypress comment")
-                .padding(.all, 16.0)
-            Divider()
-                .frame(maxWidth: .infinity)
-                .background(Color(R.color.semiLightGray.name))
-            author
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .overlay(
-            RoundedRectangle(cornerRadius: 8.0)
-                .stroke(
-                    Color(R.color.semiLightGray.name),
-                    lineWidth: 1.0
+        Group {
+            if let uiModel = uiModel {
+                VStack(alignment: .leading, spacing: 0.0) {
+                    Text(uiModel.commentBody)
+                        .padding(.all, 16.0)
+                    Divider()
+                        .frame(maxWidth: .infinity)
+                        .background(Color(R.color.semiLightGray.name))
+                    author(uiModel: uiModel)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8.0)
+                        .stroke(
+                            Color(R.color.semiLightGray.name),
+                            lineWidth: 1.0
+                        )
                 )
-        )
+            } else {
+                EmptyView()
+            }
+        }
+        .onReceive(viewModel.output.uiModel) {
+            uiModel = $0
+        }
     }
 
-    var author: some View {
+    var defaultAvatar: some View {
+        Image(R.image.defaultAvatar.name)
+            .resizable()
+            .frame(width: 25.0, height: 25.0)
+    }
+
+    init(viewModel: FeedCommentRowViewModelProtocol) {
+        self.viewModel = viewModel
+    }
+
+    func author(uiModel: UIModel) -> some View {
         HStack {
-            // TODO: Update with real data in Integrate
-            if let url = try? "https://cdn3.iconfinder.com/data/icons/avatars-15/64/_Ninja-2-512.png".asURL() {
+            if let url = uiModel.authorImage {
                 // FIXME: It blocks UI
                 WebImage(url: url)
                     .placeholder { defaultAvatar }
@@ -42,19 +63,13 @@ struct FeedCommentRow: View {
             } else {
                 defaultAvatar
             }
-            Text("cypresscypresscypresscypresscypresscypresscypresscypresscypresscypresscypresscypress")
+            Text(uiModel.authorName)
                 .foregroundColor(.green)
-            Text("August 12, 2021")
+            Text(uiModel.commentUpdatedAt)
                 .foregroundColor(.gray)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.all, 16.0)
         .background(Color(R.color.lightGray.name))
-    }
-
-    var defaultAvatar: some View {
-        Image(R.image.defaultAvatar.name)
-            .resizable()
-            .frame(width: 25.0, height: 25.0)
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/FeedComments/FeedCommentRow/FeedCommentRowViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/FeedComments/FeedCommentRow/FeedCommentRowViewModel.swift
@@ -1,0 +1,55 @@
+//
+//  FeedCommentRowViewModel.swift
+//  NimbleMedium
+//
+//  Created by Mark G on 23/09/2021.
+//
+
+import Combine
+import Resolver
+import RxCocoa
+import RxSwift
+
+// sourcery: AutoMockable
+protocol FeedCommentRowViewModelInput {}
+
+// sourcery: AutoMockable
+protocol FeedCommentRowViewModelOutput {
+
+    var id: Int { get }
+    var uiModel: Driver<FeedCommentRow.UIModel > { get }
+}
+
+// sourcery: AutoMockable
+protocol FeedCommentRowViewModelProtocol: ObservableViewModel {
+
+    var input: FeedCommentRowViewModelInput { get }
+    var output: FeedCommentRowViewModelOutput { get }
+}
+
+final class FeedCommentRowViewModel: ObservableObject, FeedCommentRowViewModelProtocol {
+
+    private let disposeBag = DisposeBag()
+
+    var input: FeedCommentRowViewModelInput { self }
+    var output: FeedCommentRowViewModelOutput { self }
+
+    let uiModel: Driver<FeedCommentRow.UIModel>
+    let id: Int
+
+    init(comment: ArticleComment) {
+        id = comment.id
+        uiModel = .just(
+            .init(
+                commentBody: comment.body,
+                commentUpdatedAt: comment.updatedAt.format(with: .monthDayYear),
+                authorName: comment.author.username,
+                authorImage: try? comment.author.image?.asURL()
+            )
+        )
+    }
+}
+
+extension FeedCommentRowViewModel: FeedCommentRowViewModelInput {}
+
+extension FeedCommentRowViewModel: FeedCommentRowViewModelOutput {}

--- a/NimbleMedium/Sources/Presentation/Modules/FeedComments/FeedCommentsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/FeedComments/FeedCommentsView.swift
@@ -6,20 +6,64 @@
 //
 
 import SwiftUI
+import Resolver
+import ToastUI
 
 struct FeedCommentsView: View {
 
+    @ObservedViewModel private var viewModel: FeedCommentsViewModelProtocol
+
+    @State var feedCommentRowViewModels: [FeedCommentRowViewModelProtocol]?
+    @State private var isErrorToastPresented = false
+    @State private var isFetching = true
+    @State private var isFetchCommentsFailed = false
+
     var body: some View {
-        ScrollView(.vertical) {
-            LazyVStack(alignment: .leading, spacing: 12.0) {
-                // TODO: Update with real data in Integrate
-                ForEach(1...3, id: \.self) { _ in
-                    FeedCommentRow()
+        Group {
+            if !isFetching, let viewModels = feedCommentRowViewModels {
+                if !viewModels.isEmpty {
+                    ScrollView(.vertical) {
+                        LazyVStack(alignment: .leading, spacing: 12.0) {
+                            ForEach(viewModels, id: \.output.id) {
+                                FeedCommentRow(viewModel: $0)
+                            }
+                        }
+                        .padding(.all, 16.0)
+                    }
+                } else {
+                    Text(Localizable.feedCommentsNoCommentMessage())
                 }
+            } else {
+                if isFetchCommentsFailed {
+                    Text(Localizable.feedCommentsNoCommentMessage())
+                } else { ProgressView() }
             }
-            .padding(.all, 16.0)
+        }
+        .toast(isPresented: $isErrorToastPresented, dismissAfter: 3.0) {
+            ToastView(Localizable.errorGeneric()) { } background: {
+                Color.clear
+            }
         }
         .navigationTitle(Localizable.feedCommentsTitle())
         .modifier(NavigationBarPrimaryStyle())
+        .onReceive(viewModel.output.didFailToFetchComments) { _ in
+            isFetching = false
+            isErrorToastPresented = true
+            isFetchCommentsFailed = true
+        }
+        .onReceive(viewModel.output.didFetchComments) {
+            isFetching = false
+        }
+        .onReceive(viewModel.output.feedCommentRowViewModels) {
+            feedCommentRowViewModels = $0
+        }
+        .onAppear { viewModel.input.fetchComments() }
+    }
+
+    init(id: String) {
+        viewModel = Resolver.resolve(
+            FeedCommentsViewModelProtocol.self,
+            args: id
+        )
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/FeedComments/FeedCommentsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/FeedComments/FeedCommentsViewModel.swift
@@ -1,0 +1,89 @@
+//
+//  FeedCommentsViewModel.swift
+//  NimbleMedium
+//
+//  Created by Mark G on 17/09/2021.
+//
+
+import RxSwift
+import RxCocoa
+import Combine
+import Resolver
+
+protocol FeedCommentsViewModelInput {
+
+    func fetchComments()
+}
+
+protocol FeedCommentsViewModelOutput {
+
+    var didFetchComments: Signal<Void> { get }
+    var didFailToFetchComments: Signal<Void> { get }
+    var feedCommentRowViewModels: Driver<[FeedCommentRowViewModelProtocol]> { get }
+}
+
+protocol FeedCommentsViewModelProtocol: ObservableViewModel {
+
+    var input: FeedCommentsViewModelInput { get }
+    var output: FeedCommentsViewModelOutput { get }
+}
+
+final class FeedCommentsViewModel: ObservableObject, FeedCommentsViewModelProtocol {
+
+    @Injected var getArticleCommentsUseCase: GetArticleCommentsUseCaseProtocol
+
+    private let disposeBag = DisposeBag()
+    private let fetchCommentsTrigger = PublishRelay<Void>()
+    private let id: String
+
+    @PublishRelayProperty var didFetchComments: Signal<Void>
+    @PublishRelayProperty var didFailToFetchComments: Signal<Void>
+    @BehaviorRelayProperty([]) var feedCommentRowViewModels: Driver<[FeedCommentRowViewModelProtocol]>
+
+    var input: FeedCommentsViewModelInput { self }
+    var output: FeedCommentsViewModelOutput { self }
+
+    init(id: String) {
+        self.id = id
+
+        fetchCommentsTrigger
+            .withUnretained(self)
+            .flatMapLatest { $0.0.fetchCommentsTriggered(owner: $0.0) }
+            .subscribe()
+            .disposed(by: disposeBag)
+    }
+}
+
+extension FeedCommentsViewModel: FeedCommentsViewModelInput {
+
+    func fetchComments() {
+        fetchCommentsTrigger.accept(())
+    }
+}
+
+extension FeedCommentsViewModel: FeedCommentsViewModelOutput {}
+
+// MARK: Private
+private extension FeedCommentsViewModel {
+
+    func fetchCommentsTriggered(owner: FeedCommentsViewModel) -> Observable<Void> {
+        getArticleCommentsUseCase.getComments(slug: id)
+            .do(
+                onSuccess: {
+                    owner.$didFetchComments.accept(())
+                    owner.$feedCommentRowViewModels.accept($0.viewModels)
+                },
+                onError: { _ in owner.$didFailToFetchComments.accept(()) }
+            )
+            .asObservable()
+            .map { _ in () }
+            .catchAndReturn(())
+    }
+}
+
+private extension Array where Element == ArticleComment {
+
+    var viewModels: [FeedCommentRowViewModelProtocol] {
+        map { Resolver.resolve(FeedCommentRowViewModelProtocol.self, args: $0) }
+    }
+}

--- a/NimbleMedium/Sources/Presentation/Modules/FeedDetail/FeedDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/FeedDetail/FeedDetailView.swift
@@ -62,6 +62,7 @@ struct FeedDetailView: View {
 
     init(slug: String) {
         self.slug = slug
+        
         viewModel = Resolver.resolve(
             FeedDetailViewModelProtocol.self,
             args: slug

--- a/NimbleMedium/Sources/Presentation/Modules/FeedDetail/FeedDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/FeedDetail/FeedDetailView.swift
@@ -18,6 +18,8 @@ struct FeedDetailView: View {
     @State private var isErrorToastPresented = false
     @State private var isFetchArticleFailed = false
 
+    private let slug: String
+
     var body: some View {
         Group {
             if let uiModel = uiModel {
@@ -43,7 +45,23 @@ struct FeedDetailView: View {
         .bind(viewModel.output.feedDetailUIModel, to: _uiModel)
     }
 
+    var comments: some View {
+        NavigationLink(
+            destination: FeedCommentsView(id: viewModel.output.id),
+            label: {
+                Text(Localizable.feedDetailCommentsTitle())
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 16.0)
+                    .frame(height: 50.0)
+                    .background(Color.green)
+                    .cornerRadius(8.0)
+            }
+        )
+        .padding(.all, 16.0)
+    }
+
     init(slug: String) {
+        self.slug = slug
         viewModel = Resolver.resolve(
             FeedDetailViewModelProtocol.self,
             args: slug
@@ -67,10 +85,7 @@ struct FeedDetailView: View {
             Text(uiModel.articleBody)
                 .padding(.horizontal, 8.0)
 
-            AppMainButton(title: Localizable.feedsCommentsTitle()) {
-                // TODO: Go to Comments screen
-            }
-            .padding(.top, 16.0)
+            comments
         }
     }
 

--- a/NimbleMedium/Sources/Presentation/Modules/FeedDetail/FeedDetailViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/FeedDetail/FeedDetailViewModel.swift
@@ -17,6 +17,7 @@ protocol FeedDetailViewModelInput {
 
 protocol FeedDetailViewModelOutput {
 
+    var id: String { get }
     var didFailToFetchArticle: Signal<Void> { get }
     var feedDetailUIModel: Driver<FeedDetailView.UIModel?> { get }
 }
@@ -31,19 +32,19 @@ final class FeedDetailViewModel: ObservableObject, FeedDetailViewModelProtocol {
 
     @Injected var getArticleUseCase: GetArticleUseCaseProtocol
     
-    let disposeBag = DisposeBag()
-    let fetchArticleTrigger = PublishRelay<Void>()
-    let slug: String
+    private let disposeBag = DisposeBag()
+    private let fetchArticleTrigger = PublishRelay<Void>()
 
     @PublishRelayProperty var didFetchArticle: Signal<Void>
     @PublishRelayProperty var didFailToFetchArticle: Signal<Void>
     @BehaviorRelayProperty(nil) var feedDetailUIModel: Driver<FeedDetailView.UIModel?>
 
+    let id: String
     var input: FeedDetailViewModelInput { self }
     var output: FeedDetailViewModelOutput { self }
 
-    init(slug: String) {
-        self.slug = slug
+    init(id: String) {
+        self.id = id
 
         fetchArticleTrigger
             .withUnretained(self)
@@ -66,7 +67,7 @@ extension FeedDetailViewModel: FeedDetailViewModelOutput {}
 private extension FeedDetailViewModel {
 
     func fetchArticleTriggered(owner: FeedDetailViewModel) -> Observable<Void> {
-        getArticleUseCase.getArticle(slug: slug)
+        getArticleUseCase.getArticle(slug: id)
         .do(
             onSuccess: {
                 owner.$feedDetailUIModel.accept(.init(article: $0))

--- a/NimbleMedium/Sources/Presentation/Modules/Home/HomeView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Home/HomeView.swift
@@ -41,8 +41,8 @@ struct HomeView: View {
 
                 draggingAnimator.reset(isOpen: isOpen)
             }
-            // TODO: Fix conflict with scrolling in FeedsView
-            .gesture(dragGesture(geo: geo))
+            // TODO: Fix dragging bug in other screens
+            // .gesture(dragGesture(geo: geo))
         }
     }
 

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/FeedComments/FeedCommentRow/FeedCommentRowViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/FeedComments/FeedCommentRow/FeedCommentRowViewModelSpec.swift
@@ -1,8 +1,8 @@
 //
-//  FeedRowViewModelSpec.swift
+//  FeedCommentRowViewModelSpec.swift
 //  NimbleMediumTests
 //
-//  Created by Mark G on 20/09/2021.
+//  Created by Mark G on 23/09/2021.
 //
 
 import Quick
@@ -14,32 +14,30 @@ import Resolver
 
 @testable import NimbleMedium
 
-final class FeedRowViewModelSpec: QuickSpec {
+final class FeedCommentRowViewModelSpec: QuickSpec {
 
     @LazyInjected var listArticlesUseCase: ListArticlesUseCaseProtocolMock
 
     override func spec() {
-        var viewModel: FeedRowViewModelProtocol!
+        var viewModel: FeedCommentRowViewModelProtocol!
         var scheduler: TestScheduler!
         var disposeBag: DisposeBag!
-        var uiModel: FeedRow.UIModel!
+        var uiModel: FeedCommentRow.UIModel!
 
         describe("a FeedsViewModel") {
 
             beforeEach {
                 Resolver.registerMockServices()
 
-                let article = APIArticleResponse.dummy.article
-                uiModel = FeedRow.UIModel(
-                    id: article.id,
-                    articleTitle: article.title,
-                    articleDescription: article.description,
-                    articleUpdatedAt: article.updatedAt.format(with: .monthDayYear),
-                    authorImage: try? article.author.image?.asURL(),
-                    authorName: article.author.username
+                let comment = APIArticleCommentsResponse.dummy.comments[0]
+                uiModel = FeedCommentRow.UIModel(
+                    commentBody: comment.body,
+                    commentUpdatedAt: comment.updatedAt.format(with: .monthDayYear),
+                    authorName: comment.author.username,
+                    authorImage: try? comment.author.image?.asURL()
                 )
 
-                viewModel = FeedRowViewModel(article: article)
+                viewModel = FeedCommentRowViewModel(comment: comment)
                 scheduler = TestScheduler(initialClock: 0)
                 disposeBag = DisposeBag()
             }

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/FeedComments/FeedCommentsViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/FeedComments/FeedCommentsViewModelSpec.swift
@@ -1,0 +1,93 @@
+//
+//  FeedCommentsViewModelSpec.swift
+//  NimbleMediumTests
+//
+//  Created by Mark G on 17/09/2021.
+//
+
+import Quick
+import Nimble
+import RxNimble
+import RxSwift
+import RxTest
+import Resolver
+
+@testable import NimbleMedium
+
+final class FeedCommentsViewModelSpec: QuickSpec {
+
+    @LazyInjected var getArticleCommentsUseCase: GetArticleCommentsUseCaseProtocolMock
+
+    override func spec() {
+        var viewModel: FeedCommentsViewModelProtocol!
+        var scheduler: TestScheduler!
+        var disposeBag: DisposeBag!
+
+        describe("a FeedCommentsViewModel") {
+
+            beforeEach {
+                Resolver.registerMockServices()
+                viewModel = FeedCommentsViewModel(id: "slug")
+                scheduler = TestScheduler(initialClock: 0)
+                disposeBag = DisposeBag()
+            }
+
+            describe("its fetchComments() call") {
+
+                context("when GetArticleCommentsUseCase return success") {
+                    let inputComments = APIArticleCommentsResponse.dummy.comments
+
+                    beforeEach {
+                        self.getArticleCommentsUseCase.getCommentsSlugReturnValue = .just(
+                            inputComments,
+                            on: scheduler,
+                            at: 10
+                        )
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.fetchComments()
+                        }
+                    }
+
+                    it("returns output didFetchComments with signal") {
+                        expect(viewModel.output.didFetchComments)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .notTo(beEmpty())
+                    }
+
+                    it("returns output article with correct value") {
+                        expect(
+                            viewModel.output.feedCommentRowViewModels
+                                .map { $0.map { $0.output.id } }
+                        )
+                        .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                            .next(0, []),
+                            .next(10, inputComments.map { $0.id })
+                        ]
+                    }
+                }
+
+                context("when GetArticleCommentsUseCase return failure") {
+
+                    beforeEach {
+                        self.getArticleCommentsUseCase.getCommentsSlugReturnValue = .error(
+                            TestError.mock,
+                            on: scheduler,
+                            at: 10
+                        )
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.fetchComments()
+                        }
+                    }
+
+                    it("returns output didFailToFetchComments with signal") {
+                        expect(viewModel.output.didFailToFetchComments)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .notTo(beEmpty())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/FeedDetail/FeedDetailViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/FeedDetail/FeedDetailViewModelSpec.swift
@@ -27,7 +27,7 @@ final class FeedDetailViewModelSpec: QuickSpec {
 
             beforeEach {
                 Resolver.registerMockServices()
-                viewModel = FeedDetailViewModel(slug: "slug")
+                viewModel = FeedDetailViewModel(id: "slug")
                 scheduler = TestScheduler(initialClock: 0)
                 disposeBag = DisposeBag()
             }


### PR DESCRIPTION
Resolved #105
Resolved #28

## What happened

- Integrate Feed Comments screen
- Link FeedDetail with Feed Comments screen

## Insight

- [x] Populate the list of comments data from server of an article and show the loading indicator on the comments tableview section when first opening the `Comments History` screen.
- [x] Make sure each comment contain: A comment body, a commenter avatar url, a commenter name and a comment updateAt timestamp.
- [x] When there is an error while loading the comments, show a temporary toast message with text: `Something went wrong. Please try again later.`
- [x] If the app is unable to load any article, show a label at the center of the screen with text: `No Comment`.
- [x] When the users tap on the create new article button in the top right navigation bar of the `Article Details` screen, navigate to the `Comments History` screen.
- [x] Once in the `Comments History` screen, the users can tap on the `Back` button to go back to the previous screen.
## Proof Of Work


https://user-images.githubusercontent.com/17875522/134609125-b49bde8a-23d3-4812-8078-8ef7d9c5498a.mov

## Known Issues
#151

