### PR TITLE
[#38] As a user, I can see my profile briefing in the left menu header

### DIFF
--- a/NimbleMedium/Resources/en.lproj/Localizable.strings
+++ b/NimbleMedium/Resources/en.lproj/Localizable.strings
@@ -21,6 +21,7 @@
 
 "menu.header.description" = "A place to share your knowledge";
 "menu.header.title" = "Nimble Medium";
+"menu.headerUsername.default" = "Current User";
 "menu.option.login" = "Login";
 "menu.option.signup" = "Signup";
 

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuHeader/SideMenuHeaderView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuHeader/SideMenuHeaderView.swift
@@ -6,23 +6,67 @@
 //
 
 import SwiftUI
+import SDWebImageSwiftUI
 
 struct SideMenuHeaderView: View {
+
+    // TODO: Update this observable to correct value in integrate task
+    @State private var isAuthenticated = true
 
     var body: some View {
         ZStack(alignment: .center) {
             Color.green.edgesIgnoringSafeArea(.all)
-            VStack(alignment: .center) {
-                Text(Localizable.menuHeaderTitle())
-                    .foregroundColor(.white)
-                    .font(.system(size: 28, weight: .heavy, design: .default))
-                    .padding()
-                Text(Localizable.menuHeaderDescription())
-                    .foregroundColor(.white)
-                    .multilineTextAlignment(.center)
-                    .padding()
+
+            if isAuthenticated {
+                authenticatedMenuHeader
+            } else {
+                unauthenticatedMenuHeader
             }
         }
+    }
+
+    var authenticatedMenuHeader: some View {
+        VStack(alignment: .center) {
+            // TODO: Update this avatar url to correct value in integrate task
+            // swiftlint:disable line_length
+            if let url = try? "https://thumbs.dreamstime.com/b/vector-illustration-avatar-dummy-logo-collection-image-icon-stock-isolated-object-set-symbol-web-137160339.jpg".asURL() {
+                // FIXME: It blocks UI
+                WebImage(url: url)
+                    .placeholder { defaultAvatar }
+                    .resizable()
+                    .frame(width: 100.0, height: 100.0)
+                    .clipShape(Circle())
+            } else {
+                defaultAvatar
+            }
+            // TODO: Update this username to correct value in integrate task
+            Text(Localizable.menuHeaderUsernameDefault())
+                .foregroundColor(.white)
+                .fontWeight(.bold)
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+                .padding()
+        }
+    }
+
+    var unauthenticatedMenuHeader: some View {
+        VStack(alignment: .center) {
+            Text(Localizable.menuHeaderTitle())
+                .foregroundColor(.white)
+                .font(.system(size: 28, weight: .heavy, design: .default))
+                .padding()
+            Text(Localizable.menuHeaderDescription())
+                .foregroundColor(.white)
+                .multilineTextAlignment(.center)
+                .padding()
+        }
+    }
+
+    var defaultAvatar: some View {
+        Image(R.image.defaultAvatar.name)
+            .resizable()
+            .frame(width: 100.0, height: 100.0)
+            .clipShape(Circle())
     }
 }
 


### PR DESCRIPTION
Resolved #38

## What happened

Once the users logged in the application successfully, opening the left navigation menu will show a brief summary of the user information in the menu header, which includes: the user avatar and the username.

## Insight

- [x] Reuse the header view region with green background from #11.
- [x] Add the user avatar image view in circle frame and center it horizontally.
- [x] Default the image view with the app's user default avatar.
- [x] Add the username label in white with bold text below the user avatar image view and center it horizontally.
- [x] Center both the above image view and the label vertically in the header region.

## Proof Of Work

<img src="https://user-images.githubusercontent.com/70877098/133971425-c7cd05a7-c7c5-4b40-af53-4c582ebd6a0a.jpeg" width="300">

