### PR TITLE
[Chore] Refactor ListArticlesUseCase

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -120,7 +120,7 @@
 		2D882EEC26F1D47300DB6560 /* FeedCommentRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D882EEB26F1D47300DB6560 /* FeedCommentRow.swift */; };
 		2D892BA726E8698700579856 /* NetworkAPIProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D892BA626E8698700579856 /* NetworkAPIProtocolMock.swift */; };
 		2D892BA926E89A6100579856 /* APIArticlesResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D892BA826E89A6100579856 /* APIArticlesResponse+Dummy.swift */; };
-		2D892BAB26E89E4500579856 /* ListArticlesUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D892BAA26E89E4500579856 /* ListArticlesUseCaseSpec.swift */; };
+		2D892BAB26E89E4500579856 /* GetListArticlesUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D892BAA26E89E4500579856 /* GetListArticlesUseCaseSpec.swift */; };
 		2D9032D026F04D96005CA3F5 /* FeedDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9032CF26F04D96005CA3F5 /* FeedDetailView.swift */; };
 		2DA4ABBF26CF90D000CF7D68 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA4ABBE26CF90D000CF7D68 /* AppEnvironment.swift */; };
 		2DA4ABC126CF91E200CF7D68 /* App+Firebase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA4ABC026CF91E200CF7D68 /* App+Firebase.swift */; };
@@ -147,7 +147,7 @@
 		2DEF1F9226E5FF4100EB93CC /* ArticleRequestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEF1F9126E5FF4100EB93CC /* ArticleRequestConfiguration.swift */; };
 		2DEF1F9426E6029200EB93CC /* DecodableArticle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEF1F9326E6029200EB93CC /* DecodableArticle.swift */; };
 		2DEF1F9626E602D200EB93CC /* DecodableProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEF1F9526E602D200EB93CC /* DecodableProfile.swift */; };
-		2DEF1F9826E6055A00EB93CC /* ListArticlesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEF1F9726E6055A00EB93CC /* ListArticlesUseCase.swift */; };
+		2DEF1F9826E6055A00EB93CC /* GetListArticlesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEF1F9726E6055A00EB93CC /* GetListArticlesUseCase.swift */; };
 		2DEF1F9A26E6092500EB93CC /* APIArticlesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEF1F9926E6092500EB93CC /* APIArticlesResponse.swift */; };
 		2DEF1FA126E612B900EB93CC /* ArticleRepositorySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEF1FA026E612B900EB93CC /* ArticleRepositorySpec.swift */; };
 		2DEF1FA726E6181F00EB93CC /* Data+Decode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEF1FA526E6181F00EB93CC /* Data+Decode.swift */; };
@@ -286,7 +286,7 @@
 		2D882EEB26F1D47300DB6560 /* FeedCommentRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCommentRow.swift; sourceTree = "<group>"; };
 		2D892BA626E8698700579856 /* NetworkAPIProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAPIProtocolMock.swift; sourceTree = "<group>"; };
 		2D892BA826E89A6100579856 /* APIArticlesResponse+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIArticlesResponse+Dummy.swift"; sourceTree = "<group>"; };
-		2D892BAA26E89E4500579856 /* ListArticlesUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListArticlesUseCaseSpec.swift; sourceTree = "<group>"; };
+		2D892BAA26E89E4500579856 /* GetListArticlesUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetListArticlesUseCaseSpec.swift; sourceTree = "<group>"; };
 		2D9032CF26F04D96005CA3F5 /* FeedDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedDetailView.swift; sourceTree = "<group>"; };
 		2DA4ABBA26CF901700CF7D68 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "NimbleMedium/Configurations/Plists/GoogleService/Production/GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		2DA4ABBB26CF901700CF7D68 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "NimbleMedium/Configurations/Plists/GoogleService/Staging/GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
@@ -320,7 +320,7 @@
 		2DEF1F9126E5FF4100EB93CC /* ArticleRequestConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleRequestConfiguration.swift; sourceTree = "<group>"; };
 		2DEF1F9326E6029200EB93CC /* DecodableArticle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodableArticle.swift; sourceTree = "<group>"; };
 		2DEF1F9526E602D200EB93CC /* DecodableProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodableProfile.swift; sourceTree = "<group>"; };
-		2DEF1F9726E6055A00EB93CC /* ListArticlesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListArticlesUseCase.swift; sourceTree = "<group>"; };
+		2DEF1F9726E6055A00EB93CC /* GetListArticlesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetListArticlesUseCase.swift; sourceTree = "<group>"; };
 		2DEF1F9926E6092500EB93CC /* APIArticlesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIArticlesResponse.swift; sourceTree = "<group>"; };
 		2DEF1FA026E612B900EB93CC /* ArticleRepositorySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleRepositorySpec.swift; sourceTree = "<group>"; };
 		2DEF1FA526E6181F00EB93CC /* Data+Decode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+Decode.swift"; sourceTree = "<group>"; };
@@ -534,7 +534,7 @@
 			children = (
 				2DC224E32702B68A008382E3 /* GetFavouritedArticlesUseCase.swift */,
 				2D73312A26F0F05D0052DCC7 /* GetArticleUseCase.swift */,
-				2DEF1F9726E6055A00EB93CC /* ListArticlesUseCase.swift */,
+				2DEF1F9726E6055A00EB93CC /* GetListArticlesUseCase.swift */,
 			);
 			path = Article;
 			sourceTree = "<group>";
@@ -578,7 +578,7 @@
 			children = (
 				2DC224E52702BB4C008382E3 /* GetFavouritedArticlesUseCaseSpec.swift */,
 				2D73313026F0F4800052DCC7 /* GetArticleUseCaseSpec.swift */,
-				2D892BAA26E89E4500579856 /* ListArticlesUseCaseSpec.swift */,
+				2D892BAA26E89E4500579856 /* GetListArticlesUseCaseSpec.swift */,
 			);
 			path = Article;
 			sourceTree = "<group>";
@@ -1905,7 +1905,7 @@
 				2D5485BC26CA077600FFE707 /* View+OnReceive.swift in Sources */,
 				2DC224E42702B68A008382E3 /* GetFavouritedArticlesUseCase.swift in Sources */,
 				24204C9E26D5289900534314 /* Background.swift in Sources */,
-				2DEF1F9826E6055A00EB93CC /* ListArticlesUseCase.swift in Sources */,
+				2DEF1F9826E6055A00EB93CC /* GetListArticlesUseCase.swift in Sources */,
 				24B277D32701C1EB00332FEA /* GetUserProfileUseCase.swift in Sources */,
 				248E13A926F054AD00439BCC /* Resolver+Injection.swift in Sources */,
 				2DEF1F9A26E6092500EB93CC /* APIArticlesResponse.swift in Sources */,
@@ -1954,7 +1954,7 @@
 				2DEF1FA726E6181F00EB93CC /* Data+Decode.swift in Sources */,
 				2D46FAF026F830B0005DD323 /* PrimitiveSequenceType+TestScheduler.swift in Sources */,
 				2DEF1FA126E612B900EB93CC /* ArticleRepositorySpec.swift in Sources */,
-				2D892BAB26E89E4500579856 /* ListArticlesUseCaseSpec.swift in Sources */,
+				2D892BAB26E89E4500579856 /* GetListArticlesUseCaseSpec.swift in Sources */,
 				2D882EE226F1CE8F00DB6560 /* APIArticleCommentsResponse+Dummy.swift in Sources */,
 				2D87822F26EB3B3A0080FEF6 /* R.generated.swift in Sources */,
 				24B277D62701C31100332FEA /* GetUserProfileUseCaseSpec.swift in Sources */,

--- a/NimbleMedium/Sources/Domain/UseCases/Article/GetListArticlesUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/Article/GetListArticlesUseCase.swift
@@ -10,7 +10,7 @@ import RxSwift
 // sourcery: AutoMockable
 protocol GetListArticlesUseCaseProtocol {
 
-    func listArticles(
+    func execute(
         tag: String?,
         author: String?,
         favorited: String?,
@@ -29,7 +29,7 @@ final class GetListArticlesUseCase: GetListArticlesUseCaseProtocol {
         self.articleRepository = articleRepository
     }
 
-    func listArticles(
+    func execute(
         tag: String?,
         author: String?,
         favorited: String?,
@@ -48,7 +48,7 @@ final class GetListArticlesUseCase: GetListArticlesUseCaseProtocol {
 
 extension GetListArticlesUseCaseProtocol {
 
-    func listArticles(
+    func execute(
         tag: String?,
         author: String?,
         favorited: String?,
@@ -56,7 +56,7 @@ extension GetListArticlesUseCaseProtocol {
         offset: Int?
     ) -> Single<[Article]> {
 
-        listArticles(
+        execute(
             tag: tag,
             author: author,
             favorited: favorited,

--- a/NimbleMedium/Sources/Domain/UseCases/Article/GetListArticlesUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/Article/GetListArticlesUseCase.swift
@@ -1,5 +1,5 @@
 //
-//  ListArticlesUseCase.swift
+//  GetListArticlesUseCase.swift
 //  NimbleMedium
 //
 //  Created by Mark G on 06/09/2021.
@@ -8,7 +8,7 @@
 import RxSwift
 
 // sourcery: AutoMockable
-protocol ListArticlesUseCaseProtocol {
+protocol GetListArticlesUseCaseProtocol {
 
     func listArticles(
         tag: String?,
@@ -19,7 +19,7 @@ protocol ListArticlesUseCaseProtocol {
     ) -> Single<[Article]>
 }
 
-final class ListArticlesUseCase: ListArticlesUseCaseProtocol {
+final class GetListArticlesUseCase: GetListArticlesUseCaseProtocol {
 
     private let articleRepository: ArticleRepositoryProtocol
 
@@ -46,7 +46,7 @@ final class ListArticlesUseCase: ListArticlesUseCaseProtocol {
     }
 }
 
-extension ListArticlesUseCaseProtocol {
+extension GetListArticlesUseCaseProtocol {
 
     func listArticles(
         tag: String?,

--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -50,8 +50,8 @@ extension Resolver: ResolverRegistering {
             GetCurrentSessionUseCase(userSessionRepository: resolve())
         }.implements(GetCurrentSessionUseCaseProtocol.self)
         register {
-            ListArticlesUseCase(articleRepository: resolve())
-        }.implements(ListArticlesUseCaseProtocol.self)
+            GetListArticlesUseCase(articleRepository: resolve())
+        }.implements(GetListArticlesUseCaseProtocol.self)
         register {
             GetUserProfileUseCase(userRepository: resolve())
         }.implements(GetUserProfileUseCaseProtocol.self)

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsViewModel.swift
@@ -89,7 +89,7 @@ extension FeedsViewModel: FeedsViewModelOutput {}
 private extension FeedsViewModel {
 
     func refreshTriggered(owner: FeedsViewModel) -> Observable<Void> {
-        getListArticlesUseCase.listArticles(
+        getListArticlesUseCase.execute(
             tag: nil,
             author: nil,
             favorited: nil,
@@ -115,7 +115,7 @@ private extension FeedsViewModel {
     func loadMoreTriggered(owner: FeedsViewModel) -> Observable<Void> {
         let offset = currentOffset + limit
 
-        return getListArticlesUseCase.listArticles(
+        return getListArticlesUseCase.execute(
             tag: nil,
             author: nil,
             favorited: nil,

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsViewModel.swift
@@ -34,7 +34,7 @@ protocol FeedsViewModelProtocol: ObservableViewModel {
 
 final class FeedsViewModel: ObservableObject, FeedsViewModelProtocol {
 
-    @Injected private var listArticlesUseCase: ListArticlesUseCaseProtocol
+    @Injected private var getListArticlesUseCase: GetListArticlesUseCaseProtocol
 
     private var currentOffset = 0
     private let limit = 10
@@ -89,7 +89,7 @@ extension FeedsViewModel: FeedsViewModelOutput {}
 private extension FeedsViewModel {
 
     func refreshTriggered(owner: FeedsViewModel) -> Observable<Void> {
-        listArticlesUseCase.listArticles(
+        getListArticlesUseCase.listArticles(
             tag: nil,
             author: nil,
             favorited: nil,
@@ -115,7 +115,7 @@ private extension FeedsViewModel {
     func loadMoreTriggered(owner: FeedsViewModel) -> Observable<Void> {
         let offset = currentOffset + limit
 
-        return listArticlesUseCase.listArticles(
+        return getListArticlesUseCase.listArticles(
             tag: nil,
             author: nil,
             favorited: nil,

--- a/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
+++ b/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
@@ -38,7 +38,7 @@ extension Resolver {
             GetCurrentSessionUseCaseProtocolMock()
         }
         .implements(GetCurrentSessionUseCaseProtocol.self)
-        Resolver.mock.register { ListArticlesUseCaseProtocolMock() }.implements(ListArticlesUseCaseProtocol.self)
+        Resolver.mock.register { GetListArticlesUseCaseProtocolMock() }.implements(GetListArticlesUseCaseProtocol.self)
         Resolver.mock.register { LoginUseCaseProtocolMock() }.implements(LoginUseCaseProtocol.self)
     }
 

--- a/NimbleMediumTests/Sources/Specs/Domain/UseCases/Article/GetListArticlesUseCaseSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Domain/UseCases/Article/GetListArticlesUseCaseSpec.swift
@@ -41,7 +41,7 @@ final class GetListArticlesUseCaseSpec: QuickSpec {
                         outputArticles = scheduler.createObserver([DecodableArticle].self)
                         articleRepository.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(inputArticles)
 
-                        usecase.listArticles(
+                        usecase.execute(
                             tag: nil,
                             author: nil,
                             favorited: nil,
@@ -69,7 +69,7 @@ final class GetListArticlesUseCaseSpec: QuickSpec {
                         outputError = scheduler.createObserver(Optional<Error>.self)
                         articleRepository.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .error(TestError.mock)
 
-                        usecase.listArticles(
+                        usecase.execute(
                             tag: nil,
                             author: nil,
                             favorited: nil,

--- a/NimbleMediumTests/Sources/Specs/Domain/UseCases/Article/GetListArticlesUseCaseSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Domain/UseCases/Article/GetListArticlesUseCaseSpec.swift
@@ -1,5 +1,5 @@
 //
-//  ListArticlesUseCaseSpec.swift
+//  GetListArticlesUseCaseSpec.swift
 //  NimbleMediumTests
 //
 //  Created by Mark G on 08/09/2021.
@@ -13,20 +13,20 @@ import RxTest
 
 @testable import NimbleMedium
 
-final class ListArticlesUseCaseSpec: QuickSpec {
+final class GetListArticlesUseCaseSpec: QuickSpec {
 
     override func spec() {
-        var usecase: ListArticlesUseCase!
+        var usecase: GetListArticlesUseCase!
         var articleRepository: ArticleRepositoryProtocolMock!
         var scheduler: TestScheduler!
         var disposeBag: DisposeBag!
 
-        describe("an ListArticlesUseCase") {
+        describe("an GetListArticlesUseCase") {
 
             beforeEach {
                 disposeBag = DisposeBag()
                 articleRepository = ArticleRepositoryProtocolMock()
-                usecase = ListArticlesUseCase(articleRepository: articleRepository)
+                usecase = GetListArticlesUseCase(articleRepository: articleRepository)
                 scheduler = TestScheduler(initialClock: 0)
             }
 

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/FeedComments/FeedCommentRow/FeedCommentRowViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/FeedComments/FeedCommentRow/FeedCommentRowViewModelSpec.swift
@@ -16,8 +16,6 @@ import Resolver
 
 final class FeedCommentRowViewModelSpec: QuickSpec {
 
-    @LazyInjected var listArticlesUseCase: ListArticlesUseCaseProtocolMock
-
     override func spec() {
         var viewModel: FeedCommentRowViewModelProtocol!
         var scheduler: TestScheduler!

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedRow/FeedRowViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedRow/FeedRowViewModelSpec.swift
@@ -16,7 +16,7 @@ import Resolver
 
 final class FeedRowViewModelSpec: QuickSpec {
 
-    @LazyInjected var listArticlesUseCase: ListArticlesUseCaseProtocolMock
+    @LazyInjected var listArticlesUseCase: GetListArticlesUseCaseProtocolMock
 
     override func spec() {
         var viewModel: FeedRowViewModelProtocol!

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedRow/FeedRowViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedRow/FeedRowViewModelSpec.swift
@@ -16,8 +16,6 @@ import Resolver
 
 final class FeedRowViewModelSpec: QuickSpec {
 
-    @LazyInjected var listArticlesUseCase: GetListArticlesUseCaseProtocolMock
-
     override func spec() {
         var viewModel: FeedRowViewModelProtocol!
         var scheduler: TestScheduler!

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsViewModelSpec.swift
@@ -16,7 +16,7 @@ import Resolver
 
 final class FeedsViewModelSpec: QuickSpec {
 
-    @LazyInjected var listArticlesUseCase: ListArticlesUseCaseProtocolMock
+    @LazyInjected var getListArticlesUseCase: GetListArticlesUseCaseProtocolMock
 
     override func spec() {
         var viewModel: FeedsViewModelProtocol!
@@ -75,7 +75,7 @@ final class FeedsViewModelSpec: QuickSpec {
 
                     beforeEach {
 
-                        self.listArticlesUseCase
+                        self.getListArticlesUseCase
                             .listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(
                                 inputArticles,
                                 on: scheduler,
@@ -108,7 +108,7 @@ final class FeedsViewModelSpec: QuickSpec {
                 context("when ListArticlesUseCase return failure") {
 
                     beforeEach {
-                        self.listArticlesUseCase
+                        self.getListArticlesUseCase
                             .listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .error(
                                 TestError.mock,
                                 on: scheduler,
@@ -140,14 +140,14 @@ final class FeedsViewModelSpec: QuickSpec {
                     let inputArticles = APIArticlesResponse.dummy.articles
 
                     beforeEach {
-                        self.listArticlesUseCase.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(
+                        self.getListArticlesUseCase.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(
                             inputArticles,
                             on: scheduler,
                             at: 10
                         )
                         scheduler.scheduleAt(5) {
                             viewModel.input.loadMore()
-                            self.listArticlesUseCase.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(
+                            self.getListArticlesUseCase.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(
                                 inputArticles,
                                 on: scheduler,
                                 at: 20
@@ -155,7 +155,7 @@ final class FeedsViewModelSpec: QuickSpec {
                         }
                         scheduler.scheduleAt(15) {
                             viewModel.input.loadMore()
-                            self.listArticlesUseCase.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(
+                            self.getListArticlesUseCase.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(
                                 [],
                                 on: scheduler,
                                 at: 30
@@ -193,7 +193,7 @@ final class FeedsViewModelSpec: QuickSpec {
                 context("when ListArticlesUseCase return failure") {
 
                     beforeEach {
-                        self.listArticlesUseCase.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .error(
+                        self.getListArticlesUseCase.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .error(
                             TestError.mock,
                             on: scheduler,
                             at: 10

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsViewModelSpec.swift
@@ -76,7 +76,7 @@ final class FeedsViewModelSpec: QuickSpec {
                     beforeEach {
 
                         self.getListArticlesUseCase
-                            .listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(
+                            .executeTagAuthorFavoritedLimitOffsetReturnValue = .just(
                                 inputArticles,
                                 on: scheduler,
                                 at: 10
@@ -109,7 +109,7 @@ final class FeedsViewModelSpec: QuickSpec {
 
                     beforeEach {
                         self.getListArticlesUseCase
-                            .listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .error(
+                            .executeTagAuthorFavoritedLimitOffsetReturnValue = .error(
                                 TestError.mock,
                                 on: scheduler,
                                 at: 10
@@ -140,14 +140,14 @@ final class FeedsViewModelSpec: QuickSpec {
                     let inputArticles = APIArticlesResponse.dummy.articles
 
                     beforeEach {
-                        self.getListArticlesUseCase.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(
+                        self.getListArticlesUseCase.executeTagAuthorFavoritedLimitOffsetReturnValue = .just(
                             inputArticles,
                             on: scheduler,
                             at: 10
                         )
                         scheduler.scheduleAt(5) {
                             viewModel.input.loadMore()
-                            self.getListArticlesUseCase.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(
+                            self.getListArticlesUseCase.executeTagAuthorFavoritedLimitOffsetReturnValue = .just(
                                 inputArticles,
                                 on: scheduler,
                                 at: 20
@@ -155,7 +155,7 @@ final class FeedsViewModelSpec: QuickSpec {
                         }
                         scheduler.scheduleAt(15) {
                             viewModel.input.loadMore()
-                            self.getListArticlesUseCase.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(
+                            self.getListArticlesUseCase.executeTagAuthorFavoritedLimitOffsetReturnValue = .just(
                                 [],
                                 on: scheduler,
                                 at: 30
@@ -193,7 +193,7 @@ final class FeedsViewModelSpec: QuickSpec {
                 context("when ListArticlesUseCase return failure") {
 
                     beforeEach {
-                        self.getListArticlesUseCase.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .error(
+                        self.getListArticlesUseCase.executeTagAuthorFavoritedLimitOffsetReturnValue = .error(
                             TestError.mock,
                             on: scheduler,
                             at: 10


### PR DESCRIPTION
## What happened

Refactor ListArticlesUseCase.

## Insight

- Update from ListArticlesUseCase to GetListArticlesUseCase for naming consistency with other use cases in the app that the first letter should be a verb.
- Update to use execute function naming.

## Proof Of Work

No visual changes, just under the hood optimization 🛠
