### PR TITLE
[66] As a user, I can see the list of created articles from the profile screen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "fastlane"
-gem "cocoapods", "1.10.1"
+gem "cocoapods", "1.10.2"
 gem 'slather'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,10 +33,10 @@ GEM
     babosa (1.0.4)
     claide (1.0.3)
     clamp (1.3.2)
-    cocoapods (1.10.1)
+    cocoapods (1.10.2)
       addressable (~> 2.6)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.10.1)
+      cocoapods-core (= 1.10.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -51,7 +51,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (~> 1.4)
       xcodeproj (>= 1.19.0, < 2.0)
-    cocoapods-core (1.10.1)
+    cocoapods-core (1.10.2)
       activesupport (> 5.0, < 6)
       addressable (~> 2.6)
       algoliasearch (~> 1.0)
@@ -61,12 +61,12 @@ GEM
       netrc (~> 0.11)
       public_suffix
       typhoeus (~> 1.0)
-    cocoapods-deintegrate (1.0.4)
-    cocoapods-downloader (1.4.0)
+    cocoapods-deintegrate (1.0.5)
+    cocoapods-downloader (1.5.1)
     cocoapods-plugins (1.0.0)
       nap
-    cocoapods-search (1.0.0)
-    cocoapods-trunk (1.5.0)
+    cocoapods-search (1.0.1)
+    cocoapods-trunk (1.6.0)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
@@ -150,7 +150,7 @@ GEM
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-firebase_app_distribution (0.2.9)
-    ffi (1.15.3)
+    ffi (1.15.4)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -281,7 +281,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
-  cocoapods (= 1.10.1)
+  cocoapods (= 1.10.2)
   fastlane
   fastlane-plugin-firebase_app_distribution
   slather

--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -130,6 +130,8 @@
 		2D892BA926E89A6100579856 /* APIArticlesResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D892BA826E89A6100579856 /* APIArticlesResponse+Dummy.swift */; };
 		2D892BAB26E89E4500579856 /* GetListArticlesUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D892BAA26E89E4500579856 /* GetListArticlesUseCaseSpec.swift */; };
 		2D9032D026F04D96005CA3F5 /* FeedDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9032CF26F04D96005CA3F5 /* FeedDetailView.swift */; };
+		2D979C30270302650084A3F8 /* GetCreatedArticlesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D979C2F270302650084A3F8 /* GetCreatedArticlesUseCase.swift */; };
+		2D979C322703034C0084A3F8 /* GetCreatedArticlesUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D979C312703034C0084A3F8 /* GetCreatedArticlesUseCaseSpec.swift */; };
 		2DA4ABBF26CF90D000CF7D68 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA4ABBE26CF90D000CF7D68 /* AppEnvironment.swift */; };
 		2DA4ABC126CF91E200CF7D68 /* App+Firebase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA4ABC026CF91E200CF7D68 /* App+Firebase.swift */; };
 		2DB04AD726C3A4AC003E65F4 /* Color+UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB04AD626C3A4AC003E65F4 /* Color+UIColor.swift */; };
@@ -304,6 +306,8 @@
 		2D892BA826E89A6100579856 /* APIArticlesResponse+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIArticlesResponse+Dummy.swift"; sourceTree = "<group>"; };
 		2D892BAA26E89E4500579856 /* GetListArticlesUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetListArticlesUseCaseSpec.swift; sourceTree = "<group>"; };
 		2D9032CF26F04D96005CA3F5 /* FeedDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedDetailView.swift; sourceTree = "<group>"; };
+		2D979C2F270302650084A3F8 /* GetCreatedArticlesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCreatedArticlesUseCase.swift; sourceTree = "<group>"; };
+		2D979C312703034C0084A3F8 /* GetCreatedArticlesUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCreatedArticlesUseCaseSpec.swift; sourceTree = "<group>"; };
 		2DA4ABBA26CF901700CF7D68 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "NimbleMedium/Configurations/Plists/GoogleService/Production/GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		2DA4ABBB26CF901700CF7D68 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "NimbleMedium/Configurations/Plists/GoogleService/Staging/GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		2DA4ABBE26CF90D000CF7D68 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
@@ -562,6 +566,7 @@
 				2DC224E32702B68A008382E3 /* GetFavouritedArticlesUseCase.swift */,
 				2D73312A26F0F05D0052DCC7 /* GetArticleUseCase.swift */,
 				2DEF1F9726E6055A00EB93CC /* GetListArticlesUseCase.swift */,
+				2D979C2F270302650084A3F8 /* GetCreatedArticlesUseCase.swift */,
 			);
 			path = Article;
 			sourceTree = "<group>";
@@ -608,6 +613,7 @@
 				2DC224E52702BB4C008382E3 /* GetFavouritedArticlesUseCaseSpec.swift */,
 				2D73313026F0F4800052DCC7 /* GetArticleUseCaseSpec.swift */,
 				2D892BAA26E89E4500579856 /* GetListArticlesUseCaseSpec.swift */,
+				2D979C312703034C0084A3F8 /* GetCreatedArticlesUseCaseSpec.swift */,
 			);
 			path = Article;
 			sourceTree = "<group>";
@@ -1956,6 +1962,7 @@
 				2D5485BE26CA0D2C00FFE707 /* PublishRelayProperty.swift in Sources */,
 				2459B31C26D74F4700ABCE61 /* AuthRequestConfiguration.swift in Sources */,
 				2D17E4F226F07996001D3F90 /* NavigationBarPrimaryStyle.swift in Sources */,
+				2D979C30270302650084A3F8 /* GetCreatedArticlesUseCase.swift in Sources */,
 				2DEF1F9426E6029200EB93CC /* DecodableArticle.swift in Sources */,
 				2DB31D4E26F18EAB007254B9 /* FeedDetailViewModel.swift in Sources */,
 				2D17E4F426F07ABA001D3F90 /* View+If.swift in Sources */,
@@ -1977,6 +1984,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2D87823126EB3C110080FEF6 /* FileResource+Decode.swift in Sources */,
+				2D979C322703034C0084A3F8 /* GetCreatedArticlesUseCaseSpec.swift in Sources */,
 				2D46FAF326F8618D005DD323 /* FeedRowViewModelSpec.swift in Sources */,
 				2D73312F26F0F3A20052DCC7 /* APIArticleResponse+Dummy.swift in Sources */,
 				2D73313126F0F4800052DCC7 /* GetArticleUseCaseSpec.swift in Sources */,

--- a/NimbleMedium/Sources/Domain/UseCases/Article/GetCreatedArticlesUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/Article/GetCreatedArticlesUseCase.swift
@@ -1,0 +1,35 @@
+//
+//  GetCreatedArticlesUseCase.swift
+//  NimbleMedium
+//
+//  Created by Mark G on 28/09/2021.
+//
+
+import RxSwift
+
+// sourcery: AutoMockable
+protocol GetCreatedArticlesUseCaseProtocol {
+
+    func execute(username: String) -> Single<[Article]>
+}
+
+final class GetCreatedArticlesUseCase: GetCreatedArticlesUseCaseProtocol {
+
+    private let articleRepository: ArticleRepositoryProtocol
+
+    init(
+        articleRepository: ArticleRepositoryProtocol
+    ) {
+        self.articleRepository = articleRepository
+    }
+
+    func execute(username: String) -> Single<[Article]> {
+        articleRepository.listArticles(
+            tag: nil,
+            author: username,
+            favorited: nil,
+            limit: 25,
+            offset: nil
+        )
+    }
+}

--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -85,6 +85,9 @@ extension Resolver: ResolverRegistering {
         register {
             GetFavouritedArticlesUseCase(articleRepository: resolve())
         }.implements(GetFavouritedArticlesUseCaseProtocol.self)
+        register {
+            GetCreatedArticlesUseCase(articleRepository: resolve())
+        }.implements(GetCreatedArticlesUseCaseProtocol.self)
     }
 
     private static func registerViewModels() {

--- a/NimbleMediumTests/Sources/Specs/Domain/UseCases/Article/GetCreatedArticlesUseCaseSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Domain/UseCases/Article/GetCreatedArticlesUseCaseSpec.swift
@@ -1,0 +1,82 @@
+//
+//  GetCreatedArticlesUseCaseSpec.swift
+//  NimbleMediumTests
+//
+//  Created by Mark G on 28/09/2021.
+//
+
+import Quick
+import Nimble
+import RxNimble
+import RxSwift
+import RxTest
+
+@testable import NimbleMedium
+
+final class GetCreatedArticlesUseCaseSpec: QuickSpec {
+
+    override func spec() {
+        var usecase: GetCreatedArticlesUseCase!
+        var articleRepository: ArticleRepositoryProtocolMock!
+        var scheduler: TestScheduler!
+        var disposeBag: DisposeBag!
+
+        describe("an GetCreatedArticlesUseCaseSpec") {
+
+            beforeEach {
+                disposeBag = DisposeBag()
+                articleRepository = ArticleRepositoryProtocolMock()
+                usecase = GetCreatedArticlesUseCase(articleRepository: articleRepository)
+                scheduler = TestScheduler(initialClock: 0)
+            }
+
+            describe("its listArticles() call") {
+
+                context("when articleRepository.listArticles() returns success") {
+
+                    let inputArticles = APIArticlesResponse.dummy.articles
+                    var outputArticles: TestableObserver<[DecodableArticle]>!
+
+                    beforeEach {
+                        outputArticles = scheduler.createObserver([DecodableArticle].self)
+                        articleRepository.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(inputArticles)
+
+                        usecase.execute(username: "any")
+                            .asObservable()
+                            .map {
+                                $0.compactMap { $0 as? DecodableArticle }
+                            }
+                            .bind(to: outputArticles)
+                            .disposed(by: disposeBag)
+                    }
+
+                    it("returns correct articles") {
+                        expect(outputArticles.events.first?.value.element) == inputArticles
+                    }
+                }
+
+                context("when articleRepository.listArticles() returns failure") {
+
+                    var outputError: TestableObserver<Error?>!
+
+                    beforeEach {
+                        outputError = scheduler.createObserver(Optional<Error>.self)
+                        articleRepository.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .error(TestError.mock)
+
+                        usecase.execute(username: "any")
+                            .asObservable()
+                            .materialize()
+                            .map { $0.error }
+                            .bind(to: outputError)
+                            .disposed(by: disposeBag)
+                    }
+
+                    it("returns correct error") {
+                        let error = outputError.events.first?.value.element as? TestError
+                        expect(error) == TestError.mock
+                    }
+                }
+            }
+        }
+    }
+}

--- a/NimbleMediumTests/Sources/Specs/Domain/UseCases/Article/GetCreatedArticlesUseCaseSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Domain/UseCases/Article/GetCreatedArticlesUseCaseSpec.swift
@@ -16,7 +16,7 @@ import RxTest
 final class GetCreatedArticlesUseCaseSpec: QuickSpec {
 
     override func spec() {
-        var usecase: GetCreatedArticlesUseCase!
+        var useCase: GetCreatedArticlesUseCase!
         var articleRepository: ArticleRepositoryProtocolMock!
         var scheduler: TestScheduler!
         var disposeBag: DisposeBag!
@@ -26,7 +26,7 @@ final class GetCreatedArticlesUseCaseSpec: QuickSpec {
             beforeEach {
                 disposeBag = DisposeBag()
                 articleRepository = ArticleRepositoryProtocolMock()
-                usecase = GetCreatedArticlesUseCase(articleRepository: articleRepository)
+                useCase = GetCreatedArticlesUseCase(articleRepository: articleRepository)
                 scheduler = TestScheduler(initialClock: 0)
             }
 
@@ -41,7 +41,7 @@ final class GetCreatedArticlesUseCaseSpec: QuickSpec {
                         outputArticles = scheduler.createObserver([DecodableArticle].self)
                         articleRepository.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .just(inputArticles)
 
-                        usecase.execute(username: "any")
+                        useCase.execute(username: "any")
                             .asObservable()
                             .map {
                                 $0.compactMap { $0 as? DecodableArticle }
@@ -63,7 +63,7 @@ final class GetCreatedArticlesUseCaseSpec: QuickSpec {
                         outputError = scheduler.createObserver(Optional<Error>.self)
                         articleRepository.listArticlesTagAuthorFavoritedLimitOffsetReturnValue = .error(TestError.mock)
 
-                        usecase.execute(username: "any")
+                        useCase.execute(username: "any")
                             .asObservable()
                             .materialize()
                             .map { $0.error }


### PR DESCRIPTION
Resolved #66

## What happened

Add GetCreatedArticles use case

## Insight

- Update cocoapod version in `Gemfile` to match with version in `Podfile.lock`

## Proof Of Work

Request
```
*** Overview *** 
URL https://conduit.productionready.io/api/articles?author=markg&limit=25
Method GET
Response Code -
Request Start Time Sep 28 2021 - 15:14:28
Duration 848ms

*** Request Header *** 
User-Agent Nimble Medium - Staging/1.2.0 (co.nimblehq.nimble-medium-stag; build:1; iOS 14.5.0) Alamofire/5.4.4
Accept-Language en;q=1.0
Accept-Encoding br;q=1.0, gzip;q=0.9, deflate;q=0.8


*** Request Body *** 
-

*** Response Header *** 
-

*** Response Body *** 
-

------------------------------------------------------------------------
------------------------------------------------------------------------
------------------------------------------------------------------------
```

Subscribe Log
```
2021-09-28 15:14:28.482: GetCreatedArticlesUseCase -> subscribed
2021-09-28 15:14:30.611: GetCreatedArticlesUseCase -> Event next([NimbleMedium.DecodableArticle(slug: "Welcome-to-RealWorld-project", title: "Welcome to RealWorld project", description: "Exemplary fullstack Medium.com clone powered by React, Angular, Node, Django, and many more", body: "See how the exact same Medium.com clone (called Conduit) is built using different frontends and backends. Yes, you can mix and match them, because they all adhere to the same API spec", tagList: ["introduction", "welcome"], createdAt: 2021-09-25 18:17:54 +0000, updatedAt: 2021-09-25 18:17:54 +0000, favorited: false, favoritesCount: 35, apiAuthor: NimbleMedium.DecodableProfile(username: "Gerome", bio: nil, image: Optional("https://realworld-temp-api.herokuapp.com/images/demo-avatar.png"), _following: DefaultCodable.Default<DefaultCodable.False>(wrappedValue: false)))])
2021-09-28 15:14:30.611: GetCreatedArticlesUseCase -> Event completed
2021-09-28 15:14:30.611: GetCreatedArticlesUseCase -> isDisposed
```
