### PR TITLE
[#161] Disable support for dark mode since the app doesn't handle it yet

### DIFF
--- a/NimbleMedium/Configurations/Plists/Info.plist
+++ b/NimbleMedium/Configurations/Plists/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
Resolved #161 

## What happened

UI: Home Screen and detail post screen have black background. Login and signup screen showing empty text fields and white texts instead of black.

https://user-images.githubusercontent.com/70877098/135197713-a8ba4c0c-7ac8-47a0-a4fe-128b425571d1.MP4

<img src="https://user-images.githubusercontent.com/70877098/135197727-180616d3-776d-444d-82eb-ed326e7f3dc3.png" width="300">

## Insight

- The app doesn't support dark mode yet. Need to disable dark mode and always showing the app as light mode regardless of the system theme settings.

## Proof Of Work

The app shows as light mode as normally:

https://user-images.githubusercontent.com/70877098/135198394-958f09cf-175b-4904-814c-14fc08bae20f.mov



