### PR TITLE
[#52] As a user, I can get my own profile information

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		240E218026FC361000EFC3B5 /* UserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 240E217F26FC361000EFC3B5 /* UserProfileView.swift */; };
+		2410D4A127041837009B4A95 /* AuthenticatedInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2410D4A027041837009B4A95 /* AuthenticatedInterceptor.swift */; };
 		241B4EEA26D3B3F4000409CC /* SideMenuActionItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */; };
 		241B99DC26DF23030041207F /* AutoMockable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B99DB26DF23030041207F /* AutoMockable.generated.swift */; };
 		241B99DE26DF34720041207F /* SignupUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B99DD26DF34720041207F /* SignupUseCase.swift */; };
@@ -38,6 +39,9 @@
 		246B387626F8A6AA003173FD /* SideMenuHeaderView+UIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246B387526F8A6AA003173FD /* SideMenuHeaderView+UIModel.swift */; };
 		246B387926F8A7D7003173FD /* SideMenuHeaderViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246B387826F8A7D7003173FD /* SideMenuHeaderViewModelSpec.swift */; };
 		246B387D26F8AA95003173FD /* UserDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246B387C26F8AA95003173FD /* UserDummy.swift */; };
+		247717332704192900BF13F2 /* NetworkAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247717322704192900BF13F2 /* NetworkAPIError.swift */; };
+		247717352704197C00BF13F2 /* AuthenticatedNetworkAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247717342704197C00BF13F2 /* AuthenticatedNetworkAPI.swift */; };
+		247717372704287B00BF13F2 /* AuthenticatedNetworkAPIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247717362704287B00BF13F2 /* AuthenticatedNetworkAPIProtocol.swift */; };
 		248E13A926F054AD00439BCC /* Resolver+Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248E13A826F054AD00439BCC /* Resolver+Injection.swift */; };
 		248E13AC26F054FD00439BCC /* Resolver in Frameworks */ = {isa = PBXBuildFile; productRef = 248E13AB26F054FD00439BCC /* Resolver */; };
 		248E13B426F07F5800439BCC /* Resolver+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248E13B326F07F5800439BCC /* Resolver+Tests.swift */; };
@@ -179,6 +183,7 @@
 		1FB4ECE354F839DF02D6976B /* Pods-NimbleMedium.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMedium.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMedium/Pods-NimbleMedium.staging.xcconfig"; sourceTree = "<group>"; };
 		21851292A064EB97674233A2 /* Pods-NimbleMediumTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.staging.xcconfig"; sourceTree = "<group>"; };
 		240E217F26FC361000EFC3B5 /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
+		2410D4A027041837009B4A95 /* AuthenticatedInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedInterceptor.swift; sourceTree = "<group>"; };
 		241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionItemView.swift; sourceTree = "<group>"; };
 		241B99DB26DF23030041207F /* AutoMockable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoMockable.generated.swift; sourceTree = "<group>"; };
 		241B99DD26DF34720041207F /* SignupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupUseCase.swift; sourceTree = "<group>"; };
@@ -208,6 +213,9 @@
 		246B387526F8A6AA003173FD /* SideMenuHeaderView+UIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SideMenuHeaderView+UIModel.swift"; sourceTree = "<group>"; };
 		246B387826F8A7D7003173FD /* SideMenuHeaderViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuHeaderViewModelSpec.swift; sourceTree = "<group>"; };
 		246B387C26F8AA95003173FD /* UserDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDummy.swift; sourceTree = "<group>"; };
+		247717322704192900BF13F2 /* NetworkAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAPIError.swift; sourceTree = "<group>"; };
+		247717342704197C00BF13F2 /* AuthenticatedNetworkAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedNetworkAPI.swift; sourceTree = "<group>"; };
+		247717362704287B00BF13F2 /* AuthenticatedNetworkAPIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedNetworkAPIProtocol.swift; sourceTree = "<group>"; };
 		248E13A826F054AD00439BCC /* Resolver+Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Resolver+Injection.swift"; sourceTree = "<group>"; };
 		248E13B326F07F5800439BCC /* Resolver+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Resolver+Tests.swift"; sourceTree = "<group>"; };
 		249042E526D4D14F00E970B6 /* SignupViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignupViewModel.swift; sourceTree = "<group>"; };
@@ -396,6 +404,14 @@
 			path = UserProfile;
 			sourceTree = "<group>";
 		};
+		2410D49F2704181A009B4A95 /* Interceptors */ = {
+			isa = PBXGroup;
+			children = (
+				2410D4A027041837009B4A95 /* AuthenticatedInterceptor.swift */,
+			);
+			path = Interceptors;
+			sourceTree = "<group>";
+		};
 		24204CA326D6465C00534314 /* SideMenuActions */ = {
 			isa = PBXGroup;
 			children = (
@@ -438,9 +454,12 @@
 		2459B30A26D748D800ABCE61 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				247717342704197C00BF13F2 /* AuthenticatedNetworkAPI.swift */,
 				2459B30826D748B700ABCE61 /* NetworkAPI.swift */,
+				247717322704192900BF13F2 /* NetworkAPIError.swift */,
 				2459B30C26D748F100ABCE61 /* NetworkAPIProtocol.swift */,
 				2459B30E26D7494800ABCE61 /* RequestConfiguration.swift */,
+				247717362704287B00BF13F2 /* AuthenticatedNetworkAPIProtocol.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -714,6 +733,7 @@
 			isa = PBXGroup;
 			children = (
 				2459B30A26D748D800ABCE61 /* Core */,
+				2410D49F2704181A009B4A95 /* Interceptors */,
 				2459B31726D74E3700ABCE61 /* Models */,
 				2459B31626D74E1800ABCE61 /* RequestConfigurations */,
 			);
@@ -1834,6 +1854,7 @@
 				2D55E4A726DF231700161052 /* Article.swift in Sources */,
 				2D4BB30326FC5930005FED5F /* FeedCommentRowViewModel.swift in Sources */,
 				2DE8C09226F97386006061B4 /* FeedRow+UIModel.swift in Sources */,
+				247717372704287B00BF13F2 /* AuthenticatedNetworkAPIProtocol.swift in Sources */,
 				2DEF1F9026E5FE8E00EB93CC /* ArticleRepositoryProtocol.swift in Sources */,
 				2D55E4AE26DF2FA800161052 /* FeedRow.swift in Sources */,
 				2D882EEC26F1D47300DB6560 /* FeedCommentRow.swift in Sources */,
@@ -1885,13 +1906,16 @@
 				24FB783D26FC3A80007534BE /* UserProfileView+UIModel.swift in Sources */,
 				2D73312926F0EFD20052DCC7 /* APIArticleResponse.swift in Sources */,
 				241B99DE26DF34720041207F /* SignupUseCase.swift in Sources */,
+				247717332704192900BF13F2 /* NetworkAPIError.swift in Sources */,
 				246B386F26F87730003173FD /* SideMenuHeaderViewModel.swift in Sources */,
 				2497356326D35BBD00177A7C /* MenuOptionButtonStyle.swift in Sources */,
 				2D882ED026F1C90200DB6560 /* ArticleComment.swift in Sources */,
 				2D5485B726C9FAAC00FFE707 /* BehaviorRelayProperty.swift in Sources */,
 				2D7BF28E26DCB4E200A30747 /* Publisher+RxSignal.swift in Sources */,
 				2D69824426C22DC700860A98 /* R.generated.swift in Sources */,
+				247717352704197C00BF13F2 /* AuthenticatedNetworkAPI.swift in Sources */,
 				2DB04AD726C3A4AC003E65F4 /* Color+UIColor.swift in Sources */,
+				2410D4A127041837009B4A95 /* AuthenticatedInterceptor.swift in Sources */,
 				2497356126D34F3200177A7C /* SideMenuActionsView.swift in Sources */,
 				2459B32826D751E300ABCE61 /* LoginUseCase.swift in Sources */,
 				2D29A70F26F44EBC001EA24F /* FeedRowViewModel.swift in Sources */,

--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -42,6 +42,10 @@
 		247717332704192900BF13F2 /* NetworkAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247717322704192900BF13F2 /* NetworkAPIError.swift */; };
 		247717352704197C00BF13F2 /* AuthenticatedNetworkAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247717342704197C00BF13F2 /* AuthenticatedNetworkAPI.swift */; };
 		247717372704287B00BF13F2 /* AuthenticatedNetworkAPIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247717362704287B00BF13F2 /* AuthenticatedNetworkAPIProtocol.swift */; };
+		247717392704329A00BF13F2 /* GetCurrentUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247717382704329A00BF13F2 /* GetCurrentUserUseCase.swift */; };
+		2477173B2704336A00BF13F2 /* GetCurrentUserUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2477173A2704336A00BF13F2 /* GetCurrentUserUseCaseSpec.swift */; };
+		2477173D27043E7900BF13F2 /* APIUserResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2477173C27043E7900BF13F2 /* APIUserResponse+Dummy.swift */; };
+		2477173F27043EAB00BF13F2 /* user.json in Resources */ = {isa = PBXBuildFile; fileRef = 2477173E27043EAB00BF13F2 /* user.json */; };
 		248E13A926F054AD00439BCC /* Resolver+Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248E13A826F054AD00439BCC /* Resolver+Injection.swift */; };
 		248E13AC26F054FD00439BCC /* Resolver in Frameworks */ = {isa = PBXBuildFile; productRef = 248E13AB26F054FD00439BCC /* Resolver */; };
 		248E13B426F07F5800439BCC /* Resolver+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248E13B326F07F5800439BCC /* Resolver+Tests.swift */; };
@@ -216,6 +220,10 @@
 		247717322704192900BF13F2 /* NetworkAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAPIError.swift; sourceTree = "<group>"; };
 		247717342704197C00BF13F2 /* AuthenticatedNetworkAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedNetworkAPI.swift; sourceTree = "<group>"; };
 		247717362704287B00BF13F2 /* AuthenticatedNetworkAPIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedNetworkAPIProtocol.swift; sourceTree = "<group>"; };
+		247717382704329A00BF13F2 /* GetCurrentUserUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentUserUseCase.swift; sourceTree = "<group>"; };
+		2477173A2704336A00BF13F2 /* GetCurrentUserUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentUserUseCaseSpec.swift; sourceTree = "<group>"; };
+		2477173C27043E7900BF13F2 /* APIUserResponse+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIUserResponse+Dummy.swift"; sourceTree = "<group>"; };
+		2477173E27043EAB00BF13F2 /* user.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = user.json; sourceTree = "<group>"; };
 		248E13A826F054AD00439BCC /* Resolver+Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Resolver+Injection.swift"; sourceTree = "<group>"; };
 		248E13B326F07F5800439BCC /* Resolver+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Resolver+Tests.swift"; sourceTree = "<group>"; };
 		249042E526D4D14F00E970B6 /* SignupViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignupViewModel.swift; sourceTree = "<group>"; };
@@ -455,11 +463,11 @@
 			isa = PBXGroup;
 			children = (
 				247717342704197C00BF13F2 /* AuthenticatedNetworkAPI.swift */,
+				247717362704287B00BF13F2 /* AuthenticatedNetworkAPIProtocol.swift */,
 				2459B30826D748B700ABCE61 /* NetworkAPI.swift */,
 				247717322704192900BF13F2 /* NetworkAPIError.swift */,
 				2459B30C26D748F100ABCE61 /* NetworkAPIProtocol.swift */,
 				2459B30E26D7494800ABCE61 /* RequestConfiguration.swift */,
-				247717362704287B00BF13F2 /* AuthenticatedNetworkAPIProtocol.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -571,6 +579,7 @@
 			isa = PBXGroup;
 			children = (
 				246B387026F87DA1003173FD /* GetCurrentSessionUseCase.swift */,
+				247717382704329A00BF13F2 /* GetCurrentUserUseCase.swift */,
 				24B277D22701C1EB00332FEA /* GetUserProfileUseCase.swift */,
 			);
 			path = User;
@@ -587,6 +596,7 @@
 		24B277D42701C2EE00332FEA /* User */ = {
 			isa = PBXGroup;
 			children = (
+				2477173A2704336A00BF13F2 /* GetCurrentUserUseCaseSpec.swift */,
 				24B277D52701C31100332FEA /* GetUserProfileUseCaseSpec.swift */,
 			);
 			path = User;
@@ -683,6 +693,7 @@
 				2D1D727726EB37BD00431679 /* articles.json */,
 				24B277DF2701CBA900332FEA /* profile.json */,
 				2D73312C26F0F35C0052DCC7 /* singleArticle.json */,
+				2477173E27043EAB00BF13F2 /* user.json */,
 			);
 			path = JSON;
 			sourceTree = "<group>";
@@ -945,6 +956,7 @@
 				2D73312E26F0F3A20052DCC7 /* APIArticleResponse+Dummy.swift */,
 				2D892BA826E89A6100579856 /* APIArticlesResponse+Dummy.swift */,
 				24B277DB2701C79400332FEA /* APIProfileResponse+Dummy.swift */,
+				2477173C27043E7900BF13F2 /* APIUserResponse+Dummy.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1597,6 +1609,7 @@
 				24B277E02701CBAA00332FEA /* profile.json in Resources */,
 				2D1D727826EB37BD00431679 /* articles.json in Resources */,
 				2D882EE026F1CE5200DB6560 /* articleComments.json in Resources */,
+				2477173F27043EAB00BF13F2 /* user.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1937,6 +1950,7 @@
 				2D55E4A926DF235000161052 /* Profile.swift in Sources */,
 				2DB2674E26BBEC4300FF05BB /* App.swift in Sources */,
 				249042F026D5042D00E970B6 /* SystemImageName.swift in Sources */,
+				247717392704329A00BF13F2 /* GetCurrentUserUseCase.swift in Sources */,
 				2DA4ABC126CF91E200CF7D68 /* App+Firebase.swift in Sources */,
 				24F3D7AA26DCE54C00DE2420 /* CodableUser.swift in Sources */,
 				2D5485BE26CA0D2C00FFE707 /* PublishRelayProperty.swift in Sources */,
@@ -1975,6 +1989,7 @@
 				2D882EE626F1CF4600DB6560 /* GetArticleCommentsUseCaseSpec.swift in Sources */,
 				2D4BB30626FC77B2005FED5F /* FeedCommentRowViewModelSpec.swift in Sources */,
 				241B99DC26DF23030041207F /* AutoMockable.generated.swift in Sources */,
+				2477173D27043E7900BF13F2 /* APIUserResponse+Dummy.swift in Sources */,
 				2DEF1FA726E6181F00EB93CC /* Data+Decode.swift in Sources */,
 				2D46FAF026F830B0005DD323 /* PrimitiveSequenceType+TestScheduler.swift in Sources */,
 				2DEF1FA126E612B900EB93CC /* ArticleRepositorySpec.swift in Sources */,
@@ -1990,6 +2005,7 @@
 				2D892BA926E89A6100579856 /* APIArticlesResponse+Dummy.swift in Sources */,
 				24B277DC2701C79400332FEA /* APIProfileResponse+Dummy.swift in Sources */,
 				2D882EE426F1CEB600DB6560 /* ArticleCommentRepositorySpec.swift in Sources */,
+				2477173B2704336A00BF13F2 /* GetCurrentUserUseCaseSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NimbleMedium/Sources/Data/Models/CodableUser.swift
+++ b/NimbleMedium/Sources/Data/Models/CodableUser.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CodableUser: User, Codable {
+struct CodableUser: User, Codable, Equatable {
 
     let email: String
     let token: String

--- a/NimbleMedium/Sources/Data/NetworkAPI/Core/AuthenticatedNetworkAPI.swift
+++ b/NimbleMedium/Sources/Data/NetworkAPI/Core/AuthenticatedNetworkAPI.swift
@@ -1,0 +1,32 @@
+//
+//  AuthenticatedNetworkAPI.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 29/09/2021.
+//
+
+import Foundation
+import Alamofire
+import RxSwift
+
+final class AuthenticatedNetworkAPI: AuthenticatedNetworkAPIProtocol {
+
+    private let decoder: JSONDecoder
+    private let session: Session
+
+    init(
+        decoder: JSONDecoder = .default,
+        keychain: KeychainProtocol
+    ) {
+        self.decoder = decoder
+        session = Session(interceptor: AuthenticatedInterceptor(keychain: keychain))
+    }
+
+    func performRequest<T>(_ configuration: RequestConfiguration, for type: T.Type) -> Single<T> where T: Decodable {
+        request(
+            session: session,
+            configuration: configuration,
+            decoder: decoder
+        )
+    }
+}

--- a/NimbleMedium/Sources/Data/NetworkAPI/Core/AuthenticatedNetworkAPIProtocol.swift
+++ b/NimbleMedium/Sources/Data/NetworkAPI/Core/AuthenticatedNetworkAPIProtocol.swift
@@ -7,4 +7,8 @@
 
 import Foundation
 
+/*
+ We need this protocol due to Resolver doesn't support dependency injection
+ for multiple instances of the same protocol
+ */
 protocol AuthenticatedNetworkAPIProtocol: NetworkAPIProtocol {}

--- a/NimbleMedium/Sources/Data/NetworkAPI/Core/AuthenticatedNetworkAPIProtocol.swift
+++ b/NimbleMedium/Sources/Data/NetworkAPI/Core/AuthenticatedNetworkAPIProtocol.swift
@@ -1,0 +1,10 @@
+//
+//  AuthenticatedNetworkAPIProtocol.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 29/09/2021.
+//
+
+import Foundation
+
+protocol AuthenticatedNetworkAPIProtocol: NetworkAPIProtocol {}

--- a/NimbleMedium/Sources/Data/NetworkAPI/Core/NetworkAPIError.swift
+++ b/NimbleMedium/Sources/Data/NetworkAPI/Core/NetworkAPIError.swift
@@ -1,0 +1,13 @@
+//
+//  NetworkAPIError.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 29/09/2021.
+//
+
+import Foundation
+
+enum NetworkAPIError: Error {
+
+    case generic
+}

--- a/NimbleMedium/Sources/Data/NetworkAPI/Core/NetworkAPIProtocol.swift
+++ b/NimbleMedium/Sources/Data/NetworkAPI/Core/NetworkAPIProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  NetworkAPIProtocol.swift
 //  NimbleMedium
 //
 //  Created by Minh Pham on 26/08/2021.

--- a/NimbleMedium/Sources/Data/NetworkAPI/Core/RequestConfiguration.swift
+++ b/NimbleMedium/Sources/Data/NetworkAPI/Core/RequestConfiguration.swift
@@ -39,9 +39,7 @@ extension RequestConfiguration {
     }
 
     var headers: HTTPHeaders? {
-        HTTPHeaders([
-            HTTPHeader.contentType("application/json; charset=utf-8")
-        ])
+        nil
     }
 
     var interceptor: RequestInterceptor? {

--- a/NimbleMedium/Sources/Data/NetworkAPI/Core/RequestConfiguration.swift
+++ b/NimbleMedium/Sources/Data/NetworkAPI/Core/RequestConfiguration.swift
@@ -39,7 +39,9 @@ extension RequestConfiguration {
     }
 
     var headers: HTTPHeaders? {
-        nil
+        HTTPHeaders([
+            HTTPHeader.contentType("application/json; charset=utf-8")
+        ])
     }
 
     var interceptor: RequestInterceptor? {

--- a/NimbleMedium/Sources/Data/NetworkAPI/Interceptors/AuthenticatedInterceptor.swift
+++ b/NimbleMedium/Sources/Data/NetworkAPI/Interceptors/AuthenticatedInterceptor.swift
@@ -1,0 +1,28 @@
+//
+//  AuthenticatedInterceptor.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 29/09/2021.
+//
+
+import Foundation
+import Alamofire
+
+final class AuthenticatedInterceptor: RequestInterceptor {
+
+    private let keychain: KeychainProtocol
+
+    init(keychain: KeychainProtocol) {
+        self.keychain = keychain
+    }
+
+    func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        var request = urlRequest
+        if let accessToken = try? keychain.get(.user)?.token {
+            request.headers.add(name: "Authorization", value: "Token \(accessToken)")
+            completion(.success(request))
+        } else {
+            completion(.failure(NetworkAPIError.generic))
+        }
+    }
+}

--- a/NimbleMedium/Sources/Data/NetworkAPI/RequestConfigurations/AuthRequestConfiguration.swift
+++ b/NimbleMedium/Sources/Data/NetworkAPI/RequestConfigurations/AuthRequestConfiguration.swift
@@ -22,9 +22,10 @@ extension AuthRequestConfiguration: RequestConfiguration {
         switch self {
         case .login:
             return "/users/login"
-        case .signup, .user:
+        case .signup:
             return "/users"
-
+        case .user:
+            return "/user"
         }
     }
 

--- a/NimbleMedium/Sources/Data/NetworkAPI/RequestConfigurations/AuthRequestConfiguration.swift
+++ b/NimbleMedium/Sources/Data/NetworkAPI/RequestConfigurations/AuthRequestConfiguration.swift
@@ -11,6 +11,7 @@ enum AuthRequestConfiguration {
 
     case login(email: String, password: String)
     case signup(username: String, email: String, password: String)
+    case user
 }
 
 extension AuthRequestConfiguration: RequestConfiguration {
@@ -21,8 +22,9 @@ extension AuthRequestConfiguration: RequestConfiguration {
         switch self {
         case .login:
             return "/users/login"
-        case .signup:
+        case .signup, .user:
             return "/users"
+
         }
     }
 
@@ -30,6 +32,8 @@ extension AuthRequestConfiguration: RequestConfiguration {
         switch self {
         case .login, .signup:
             return .post
+        case .user:
+            return .get
         }
     }
 
@@ -50,12 +54,10 @@ extension AuthRequestConfiguration: RequestConfiguration {
                     "password": password
                 ]
             ]
+        case .user:
+            return nil
         }
     }
 
     var encoding: ParameterEncoding { URLEncoding.default }
-
-    var headers: HTTPHeaders? { nil }
-
-    var interceptor: RequestInterceptor? { nil }
 }

--- a/NimbleMedium/Sources/Data/Repositories/Auth/AuthRepository.swift
+++ b/NimbleMedium/Sources/Data/Repositories/Auth/AuthRepository.swift
@@ -10,11 +10,11 @@ import RxSwift
 final class AuthRepository: AuthRepositoryProtocol {
 
     private let networkAPI: NetworkAPIProtocol
-    private let authenticatedNetworkAPI: NetworkAPIProtocol
+    private let authenticatedNetworkAPI: AuthenticatedNetworkAPIProtocol
 
     init(
         networkAPI: NetworkAPIProtocol,
-        authenticatedNetworkAPI: NetworkAPIProtocol
+        authenticatedNetworkAPI: AuthenticatedNetworkAPIProtocol
     ) {
         self.networkAPI = networkAPI
         self.authenticatedNetworkAPI = authenticatedNetworkAPI

--- a/NimbleMedium/Sources/Data/Repositories/Auth/AuthRepository.swift
+++ b/NimbleMedium/Sources/Data/Repositories/Auth/AuthRepository.swift
@@ -10,9 +10,21 @@ import RxSwift
 final class AuthRepository: AuthRepositoryProtocol {
 
     private let networkAPI: NetworkAPIProtocol
+    private let authenticatedNetworkAPI: NetworkAPIProtocol
 
-    init(networkAPI: NetworkAPIProtocol) {
+    init(
+        networkAPI: NetworkAPIProtocol,
+        authenticatedNetworkAPI: NetworkAPIProtocol
+    ) {
         self.networkAPI = networkAPI
+        self.authenticatedNetworkAPI = authenticatedNetworkAPI
+    }
+
+    func getCurrentUser() -> Single<User> {
+        let requestConfiguration = AuthRequestConfiguration.user
+        return authenticatedNetworkAPI
+            .performRequest(requestConfiguration, for: APIUserResponse.self)
+            .map { $0.user as User }
     }
 
     func login(email: String, password: String) -> Single<User> {

--- a/NimbleMedium/Sources/Domain/Repositories/Auth/AuthRepositoryProtocol.swift
+++ b/NimbleMedium/Sources/Domain/Repositories/Auth/AuthRepositoryProtocol.swift
@@ -7,6 +7,7 @@
 
 import RxSwift
 
+// sourcery: AutoMockable
 protocol AuthRepositoryProtocol: AnyObject {
 
     func getCurrentUser() -> Single<User>

--- a/NimbleMedium/Sources/Domain/Repositories/Auth/AuthRepositoryProtocol.swift
+++ b/NimbleMedium/Sources/Domain/Repositories/Auth/AuthRepositoryProtocol.swift
@@ -9,6 +9,8 @@ import RxSwift
 
 protocol AuthRepositoryProtocol: AnyObject {
 
+    func getCurrentUser() -> Single<User>
+
     func login(email: String, password: String) -> Single<User>
 
     func signup(username: String, email: String, password: String) -> Single<User>

--- a/NimbleMedium/Sources/Domain/UseCases/User/GetCurrentUserUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/User/GetCurrentUserUseCase.swift
@@ -1,0 +1,29 @@
+//
+//  GetCurrentUserUseCase.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 29/09/2021.
+//
+
+import RxSwift
+
+// sourcery: AutoMockable
+protocol GetCurrentUserUseCaseProtocol: AnyObject {
+
+    func execute() -> Single<User>
+}
+
+final class GetCurrentUserUseCase: GetCurrentUserUseCaseProtocol {
+
+    private let authRepository: AuthRepositoryProtocol
+
+    init(
+        authRepository: AuthRepositoryProtocol
+    ) {
+        self.authRepository = authRepository
+    }
+
+    func execute() -> Single<User> {
+        authRepository.getCurrentUser()
+    }
+}

--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -56,6 +56,9 @@ extension Resolver: ResolverRegistering {
             GetCurrentSessionUseCase(userSessionRepository: resolve())
         }.implements(GetCurrentSessionUseCaseProtocol.self)
         register {
+            GetCurrentUserUseCase(authRepository: resolve())
+        }.implements(GetCurrentUserUseCaseProtocol.self)
+        register {
             GetListArticlesUseCase(articleRepository: resolve())
         }.implements(GetListArticlesUseCaseProtocol.self)
         register {

--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -13,8 +13,11 @@ extension Resolver: ResolverRegistering {
     public static func registerAllServices() {
         defaultScope = .graph
 
-        register { NetworkAPI() }.implements(NetworkAPIProtocol.self).scope(.application)
         register { Keychain.default }.implements(KeychainProtocol.self).scope(.application)
+        register { NetworkAPI() }.implements(NetworkAPIProtocol.self).scope(.application)
+        register {
+            AuthenticatedNetworkAPI(keychain: resolve())
+        }.implements(AuthenticatedNetworkAPIProtocol.self).scope(.application)
 
         registerRepositories()
         registerUseCases()
@@ -23,7 +26,10 @@ extension Resolver: ResolverRegistering {
 
     private static func registerRepositories() {
         register {
-            AuthRepository(networkAPI: resolve())
+            AuthRepository(
+                networkAPI: resolve(),
+                authenticatedNetworkAPI: resolve()
+            )
         }.implements(AuthRepositoryProtocol.self)
         register {
             ArticleRepository(networkAPI: resolve())

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsViewModel.swift
@@ -52,7 +52,6 @@ final class FeedsViewModel: ObservableObject, FeedsViewModelProtocol {
     var output: FeedsViewModelOutput { self }
 
     init() {
-
         refreshTrigger
             .withUnretained(self)
             .flatMapLatest { $0.0.refreshTriggered(owner: $0.0) }

--- a/NimbleMediumTests/Resources/JSON/user.json
+++ b/NimbleMediumTests/Resources/JSON/user.json
@@ -1,0 +1,9 @@
+{
+  "user": {
+    "email": "jake@jake.jake",
+    "token": "jwt.token.here",
+    "username": "jake",
+    "bio": "I work at statefarm",
+    "image": null
+  }
+}

--- a/NimbleMediumTests/Sources/Dummy/Data/Models/APIUserResponse+Dummy.swift
+++ b/NimbleMediumTests/Sources/Dummy/Data/Models/APIUserResponse+Dummy.swift
@@ -1,0 +1,15 @@
+//
+//  APIUserResponse+Dummy.swift
+//  NimbleMediumTests
+//
+//  Created by Minh Pham on 29/09/2021.
+//
+
+@testable import NimbleMedium
+
+extension APIUserResponse {
+
+    static let dummy: APIUserResponse = {
+        R.file.userJson.decoded()
+    }()
+}

--- a/NimbleMediumTests/Sources/Specs/Domain/UseCases/User/GetCurrentUserUseCaseSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Domain/UseCases/User/GetCurrentUserUseCaseSpec.swift
@@ -1,8 +1,8 @@
 //
-//  GetUserProfileUseCaseSpec.swift
+//  GetCurrentUserUseCaseSpec.swift
 //  NimbleMediumTests
 //
-//  Created by Minh Pham on 27/09/2021.
+//  Created by Minh Pham on 29/09/2021.
 //
 
 import Quick
@@ -13,60 +13,60 @@ import RxTest
 
 @testable import NimbleMedium
 
-final class GetUserProfileUseCaseSpec: QuickSpec {
+final class GetCurrentUserUseCaseSpec: QuickSpec {
 
     override func spec() {
-        var usecase: GetUserProfileUseCase!
-        var userRepository: UserRepositoryProtocolMock!
+        var usecase: GetCurrentUserUseCase!
+        var authRepository: AuthRepositoryProtocolMock!
         var scheduler: TestScheduler!
         var disposeBag: DisposeBag!
 
-        describe("a GetUserProfileUseCase") {
+        describe("a GetCurrentUserUseCase") {
 
             beforeEach {
                 disposeBag = DisposeBag()
-                userRepository = UserRepositoryProtocolMock()
-                usecase = GetUserProfileUseCase(userRepository: userRepository)
+                authRepository = AuthRepositoryProtocolMock()
+                usecase = GetCurrentUserUseCase(authRepository: authRepository)
                 scheduler = TestScheduler(initialClock: 0)
             }
 
             describe("its execute() call") {
 
-                context("when userRepository.getUserProfile() returns success") {
+                context("when authRepository.getCurrentUser() returns success") {
 
-                    let inputProfile = APIProfileResponse.dummy.profile
-                    var outputProfile: TestableObserver<DecodableProfile>!
+                    let inputUser = APIUserResponse.dummy.user
+                    var outputUser: TestableObserver<CodableUser>!
 
                     beforeEach {
-                        outputProfile = scheduler.createObserver(DecodableProfile.self)
-                        userRepository.getUserProfileUsernameReturnValue = .just(inputProfile)
+                        outputUser = scheduler.createObserver(CodableUser.self)
+                        authRepository.getCurrentUserReturnValue = .just(inputUser)
 
-                        usecase.execute(username: "username")
+                        usecase.execute()
                             .asObservable()
                             .compactMap {
-                                $0 as? DecodableProfile
+                                $0 as? CodableUser
                             }
-                            .bind(to: outputProfile)
+                            .bind(to: outputUser)
                             .disposed(by: disposeBag)
                     }
 
-                    it("returns correct profile") {
-                        expect(outputProfile.events) == [
-                            .next(0, inputProfile),
+                    it("returns correct user") {
+                        expect(outputUser.events) == [
+                            .next(0, inputUser),
                             .completed(0)
                         ]
                     }
                 }
 
-                context("when userRepository.getUserProfile() returns failure") {
+                context("when authRepository.getCurrentUser() returns failure") {
 
                     var outputError: TestableObserver<Error?>!
 
                     beforeEach {
                         outputError = scheduler.createObserver(Optional<Error>.self)
-                        userRepository.getUserProfileUsernameReturnValue = .error(TestError.mock)
+                        authRepository.getCurrentUserReturnValue =  .error(TestError.mock)
 
-                        usecase.execute(username: "username")
+                        usecase.execute()
                             .asObservable()
                             .materialize()
                             .map { $0.error }


### PR DESCRIPTION
Resolved #52

## What happened

Once authenticated, the users will be able to get their own profile from server.

## Insight

- [x] Implement the API for getting current user profile via this [endpoint](https://github.com/gothinkster/realworld/tree/master/api#get-current-user).
- [x] Add support for authenticated request by using tokens. 
- [x] Create a usecase for getting current user profile for later usage in integrate task.
- [x] Parse the response into the corresponding model.

## Proof Of Work

Request log with tokens (no response log for now due to server issue): 
```
GET 'https://conduit.productionready.io/api/user':
cURL:
$ curl -v \
	-X GET \
	-H "Accept-Language: en-VN;q=1.0, vi-VN;q=0.9, th-VN;q=0.8" \
	-H "Accept-Encoding: br;q=1.0, gzip;q=0.9, deflate;q=0.8" \
	-H "User-Agent: Nimble Medium - Staging/1.2.0 (co.nimblehq.nimble-medium-stag; build:1; iOS 14.8.0) Alamofire/5.4.4" \
	-H "Authorization: Token eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MjAxNTEwLCJ1c2VybmFtZSI6Ik1pa2V5IiwiZXhwIjoxNjM3MzE5MTc0fQ.K5DxymXZrSPdndbLga7YQSunB4HLDHmnU0MPqeQ2V3U" \
	"https://conduit.productionready.io/api/user"
2021-09-29 14:41:39.342214+0700 Nimble Medium - Staging[2930:2067420] [connection] nw_endpoint_handler_set_adaptive_read_handler [C1.1 2606:4700:3033::6815:3697.443 ready channel-flow (satisfied (Path is satisfied), viable, interface: en0, ipv4, ipv6, dns)] unregister notification for read_timeout failed
2021-09-29 14:41:39.342282+0700 Nimble Medium - Staging[2930:2067420] [connection] nw_endpoint_handler_set_adaptive_write_handler [C1.1 2606:4700:3033::6815:3697.443 ready channel-flow (satisfied (Path is satisfied), viable, interface: en0, ipv4, ipv6, dns)] unregister notification for write_timeout failed
2021-09-29 14:41:39.342389+0700 Nimble Medium - Staging[2930:2067423] CredStore - performQuery - Error copying matching creds.  Error=-25300, query={
    class = inet;
    "m_Limit" = "m_LimitAll";
    ptcl = htps;
    "r_Attributes" = 1;
    sdmn = "conduit.productionready.io";
    srvr = "conduit.productionready.io";
    sync = syna;
}
```

Tests run successfully for the new use case:

<img width="1060" alt="Screen Shot 2021-09-29 at 13 36 02" src="https://user-images.githubusercontent.com/70877098/135224967-c16584e4-69f5-491b-9388-41f247dcd5d2.png">

Coverage:

<img width="1056" alt="Screen Shot 2021-09-29 at 13 35 30" src="https://user-images.githubusercontent.com/70877098/135224987-ec0b8a38-c92e-4796-a8a8-3b508885c425.png">

