### PR TITLE
[Chore] Refactor Login and Sign ViewModels and add mapToVoid extension

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		249042F026D5042D00E970B6 /* SystemImageName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249042EF26D5042D00E970B6 /* SystemImageName.swift */; };
 		2497356126D34F3200177A7C /* SideMenuActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2497356026D34F3200177A7C /* SideMenuActionsView.swift */; };
 		2497356326D35BBD00177A7C /* MenuOptionButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */; };
+		24AB4A662706C4010067CD0D /* ObservableType+Void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AB4A652706C4010067CD0D /* ObservableType+Void.swift */; };
 		24B277D32701C1EB00332FEA /* GetUserProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B277D22701C1EB00332FEA /* GetUserProfileUseCase.swift */; };
 		24B277D62701C31100332FEA /* GetUserProfileUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B277D52701C31100332FEA /* GetUserProfileUseCaseSpec.swift */; };
 		24B277DC2701C79400332FEA /* APIProfileResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B277DB2701C79400332FEA /* APIProfileResponse+Dummy.swift */; };
@@ -234,6 +235,7 @@
 		249042EF26D5042D00E970B6 /* SystemImageName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemImageName.swift; sourceTree = "<group>"; };
 		2497356026D34F3200177A7C /* SideMenuActionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionsView.swift; sourceTree = "<group>"; };
 		2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionButtonStyle.swift; sourceTree = "<group>"; };
+		24AB4A652706C4010067CD0D /* ObservableType+Void.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ObservableType+Void.swift"; sourceTree = "<group>"; };
 		24B277D22701C1EB00332FEA /* GetUserProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUserProfileUseCase.swift; sourceTree = "<group>"; };
 		24B277D52701C31100332FEA /* GetUserProfileUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUserProfileUseCaseSpec.swift; sourceTree = "<group>"; };
 		24B277DB2701C79400332FEA /* APIProfileResponse+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIProfileResponse+Dummy.swift"; sourceTree = "<group>"; };
@@ -558,6 +560,14 @@
 				249042E526D4D14F00E970B6 /* SignupViewModel.swift */,
 			);
 			path = Signup;
+			sourceTree = "<group>";
+		};
+		24AB4A642706C3EA0067CD0D /* Rx */ = {
+			isa = PBXGroup;
+			children = (
+				24AB4A652706C4010067CD0D /* ObservableType+Void.swift */,
+			);
+			path = Rx;
 			sourceTree = "<group>";
 		};
 		24B277CE2701C06100332FEA /* Article */ = {
@@ -893,6 +903,7 @@
 			children = (
 				2D7BF28C26DCB4CC00A30747 /* Combine */,
 				2D303B3C26C28AE900EEF1C0 /* Foundation */,
+				24AB4A642706C3EA0067CD0D /* Rx */,
 				2D303B3D26C28B6500EEF1C0 /* SwiftUI */,
 			);
 			path = Extensions;
@@ -1872,6 +1883,7 @@
 				2459B31F26D7503A00ABCE61 /* AuthRepository.swift in Sources */,
 				2D55E4A726DF231700161052 /* Article.swift in Sources */,
 				2D4BB30326FC5930005FED5F /* FeedCommentRowViewModel.swift in Sources */,
+				24AB4A662706C4010067CD0D /* ObservableType+Void.swift in Sources */,
 				2DE8C09226F97386006061B4 /* FeedRow+UIModel.swift in Sources */,
 				247717372704287B00BF13F2 /* AuthenticatedNetworkAPIProtocol.swift in Sources */,
 				2DEF1F9026E5FE8E00EB93CC /* ArticleRepositoryProtocol.swift in Sources */,

--- a/NimbleMedium/Sources/Constants/Constants+API.swift
+++ b/NimbleMedium/Sources/Constants/Constants+API.swift
@@ -9,5 +9,5 @@
 extension Constants.API {
 
     // For fixing performance issues and the presence of NSFW content on the current API, we encourage you to use the new temporary API: https://realworld-temp-api.herokuapp.com/api Please keep in mind we'll soon move back to the current API: https://conduit.productionready.io/api
-    static let baseURL: String = "https://conduit.productionready.io/api"
+    static let baseURL: String = "https://realworld-temp-api.herokuapp.com/api"
 }

--- a/NimbleMedium/Sources/Domain/UseCases/Auth/LoginUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/Auth/LoginUseCase.swift
@@ -10,7 +10,7 @@ import RxSwift
 // sourcery: AutoMockable
 protocol LoginUseCaseProtocol: AnyObject {
 
-    func login(email: String, password: String) -> Completable
+    func execute(email: String, password: String) -> Completable
 }
 
 final class LoginUseCase: LoginUseCaseProtocol {
@@ -26,7 +26,7 @@ final class LoginUseCase: LoginUseCaseProtocol {
         self.userSessionRepository = userSessionRepository
     }
 
-    func login(email: String, password: String) -> Completable {
+    func execute(email: String, password: String) -> Completable {
         authRepository
             .login(email: email, password: password)
             .asObservable()

--- a/NimbleMedium/Sources/Domain/UseCases/Auth/SignupUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/Auth/SignupUseCase.swift
@@ -28,9 +28,11 @@ final class SignupUseCase: SignupUseCaseProtocol {
     func execute(username: String, email: String, password: String) -> Completable {
         authRepository
             .signup(username: username, email: email, password: password)
-            .flatMapCompletable({ [weak self] user in
-                guard let self = self else { return Completable.empty() }
-                return self.userSessionRepository.saveUser(user)
-            })
+            .asObservable()
+            .withUnretained(self)
+            .flatMapLatest { owner, user -> Completable in
+                owner.userSessionRepository.saveUser(user)
+            }
+            .asCompletable()
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/FeedComments/FeedCommentsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/FeedComments/FeedCommentsViewModel.swift
@@ -76,7 +76,7 @@ private extension FeedCommentsViewModel {
                 onError: { _ in owner.$didFailToFetchComments.accept(()) }
             )
             .asObservable()
-            .map { _ in () }
+            .mapToVoid()
             .catchAndReturn(())
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/FeedDetail/FeedDetailViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/FeedDetail/FeedDetailViewModel.swift
@@ -75,7 +75,7 @@ private extension FeedDetailViewModel {
             onError: { _ in owner.$didFailToFetchArticle.accept(()) }
         )
         .asObservable()
-        .map { _ in () }
+        .mapToVoid()
         .catchAndReturn(())
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsViewModel.swift
@@ -107,7 +107,7 @@ private extension FeedsViewModel {
             }
         )
         .asObservable()
-        .map { _ in () }
+        .mapToVoid()
         .catchAndReturn(())
     }
 
@@ -136,7 +136,7 @@ private extension FeedsViewModel {
             }
         )
         .asObservable()
-        .map { _ in () }
+        .mapToVoid()
         .catchAndReturn(())
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginViewModel.swift
@@ -9,8 +9,6 @@ import RxSwift
 import RxCocoa
 import Resolver
 
-typealias LoginParams = (email: String, password: String)
-
 protocol LoginViewModelInput {
 
     func didTapLoginButton(email: String, password: String)
@@ -32,6 +30,8 @@ protocol LoginViewModelProtocol: ObservableViewModel {
 }
 
 final class LoginViewModel: ObservableObject, LoginViewModelProtocol {
+
+    typealias LoginParams = (email: String, password: String)
 
     private let disposeBag = DisposeBag()
     private let loginTrigger = PublishRelay<LoginParams>()

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginViewModel.swift
@@ -9,6 +9,8 @@ import RxSwift
 import RxCocoa
 import Resolver
 
+typealias LoginParams = (email: String, password: String)
+
 protocol LoginViewModelInput {
 
     func didTapLoginButton(email: String, password: String)
@@ -32,7 +34,7 @@ protocol LoginViewModelProtocol: ObservableViewModel {
 final class LoginViewModel: ObservableObject, LoginViewModelProtocol {
 
     private let disposeBag = DisposeBag()
-    private let loginTrigger = PublishRelay<(email: String, password: String)>()
+    private let loginTrigger = PublishRelay<LoginParams>()
 
     var input: LoginViewModelInput { self }
     var output: LoginViewModelOutput { self }
@@ -47,23 +49,8 @@ final class LoginViewModel: ObservableObject, LoginViewModelProtocol {
     init() {
         loginTrigger
             .withUnretained(self)
-            .flatMapLatest { owner, inputs in
-                owner.loginUseCase
-                    .login(email: inputs.email, password: inputs.password)
-                    .asObservable()
-                    .materialize()
-            }
-            .subscribe(
-                with: self,
-                onNext: { owner, event in
-                    owner.$isLoading.accept(false)
-                    if let error = event.error {
-                        owner.$errorMessage.accept(error.detail)
-                    } else {
-                        owner.$didLogin.accept(())
-                    }
-                }
-            )
+            .flatMapLatest { owner, inputs in owner.loginTriggered(owner: owner, inputs: inputs) }
+            .subscribe()
             .disposed(by: disposeBag)
     }
 }
@@ -81,3 +68,21 @@ extension LoginViewModel: LoginViewModelInput {
 }
 
 extension LoginViewModel: LoginViewModelOutput {}
+
+private extension LoginViewModel {
+
+    func loginTriggered(owner: LoginViewModel, inputs: LoginParams) -> Observable<Void> {
+        loginUseCase.execute(email: inputs.email, password: inputs.password)
+            .do(
+                onError: { error in
+                    owner.$isLoading.accept(false)
+                    owner.$errorMessage.accept(error.detail)
+                },
+                onCompleted: {
+                    owner.$isLoading.accept(false)
+                    owner.$didLogin.accept(())
+                }
+            )
+            .andThen(.just(Void()))
+    }
+}

--- a/NimbleMedium/Sources/Presentation/Modules/Signup/SignupViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Signup/SignupViewModel.swift
@@ -9,8 +9,6 @@ import Resolver
 import RxCocoa
 import RxSwift
 
-typealias SignupParams = (username: String, email: String, password: String)
-
 protocol SignupViewModelInput {
 
     func didTapSignupButton(username: String, email: String, password: String)
@@ -32,6 +30,8 @@ protocol SignupViewModelProtocol: ObservableViewModel {
 }
 
 final class SignupViewModel: ObservableObject, SignupViewModelProtocol {
+
+    typealias SignupParams = (username: String, email: String, password: String)
 
     private let disposeBag = DisposeBag()
     private let signupTrigger = PublishRelay<SignupParams>()

--- a/NimbleMedium/Sources/Supports/Extensions/Rx/ObservableType+Void.swift
+++ b/NimbleMedium/Sources/Supports/Extensions/Rx/ObservableType+Void.swift
@@ -1,0 +1,30 @@
+//
+//  ObservableType+Void.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 01/10/2021.
+//
+
+import RxSwift
+import RxCocoa
+
+extension ObservableType {
+
+    func mapToVoid() -> Observable<Void> {
+        map { _ in }
+    }
+}
+
+extension SharedSequenceConvertibleType {
+
+    func mapToVoid() -> SharedSequence<SharingStrategy, Void> {
+        map { _ in }
+    }
+}
+
+extension PrimitiveSequenceType where Trait == SingleTrait {
+
+    func mapToVoid() -> PrimitiveSequence<Trait, Void> {
+        map { _ in }
+    }
+}

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/Login/LoginViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/Login/LoginViewModelSpec.swift
@@ -38,7 +38,7 @@ final class LoginViewModelSpec: QuickSpec {
                 context("when logging in with email and password returns success") {
 
                     beforeEach {
-                        self.loginUseCase.loginEmailPasswordReturnValue = Completable.create { completable in
+                        self.loginUseCase.executeEmailPasswordReturnValue = Completable.create { completable in
                             scheduler.scheduleAt(100) { completable(.completed) }
                             return Disposables.create()
                         }
@@ -72,7 +72,7 @@ final class LoginViewModelSpec: QuickSpec {
                 context("when login with email and password returns failure") {
 
                     beforeEach {
-                        self.loginUseCase.loginEmailPasswordReturnValue = Completable.create { completable in
+                        self.loginUseCase.executeEmailPasswordReturnValue = Completable.create { completable in
                             scheduler.scheduleAt(100) {
                                 completable(.error(TestError.mock))
                             }


### PR DESCRIPTION
## What happened

Refactor Login and Sign ViewModels and add mapToVoid extension for consistency with other places.

## Insight

- Update Login and Signup ViewModels to use private extensions with for use case triggering.
- Use type aliases for the tuple declarations.
- Add mapToVoid extension and apply to all places in the application.
- Refactor the use cases's function names to` execute` for  Login and Signup use cases.
- Force to use: `https://realworld-temp-api.herokuapp.com/api` since the production endpoint: `https://conduit.productionready.io/api` is completely unusable with Authentication features.

## Proof Of Work

No visual changes, just under the hood optimization 🛠
