### PR TITLE
[#64] As a user, I can view other author profile details from the article details screen when not logged in

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		249042F026D5042D00E970B6 /* SystemImageName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249042EF26D5042D00E970B6 /* SystemImageName.swift */; };
 		2497356126D34F3200177A7C /* SideMenuActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2497356026D34F3200177A7C /* SideMenuActionsView.swift */; };
 		2497356326D35BBD00177A7C /* MenuOptionButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */; };
+		249D8086270AFD88000775BC /* UserProfileViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249D8085270AFD88000775BC /* UserProfileViewModelSpec.swift */; };
 		24AB4A662706C4010067CD0D /* ObservableType+Void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AB4A652706C4010067CD0D /* ObservableType+Void.swift */; };
 		24AB4A68270AE58F0067CD0D /* UserProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AB4A67270AE58F0067CD0D /* UserProfileViewModel.swift */; };
 		24B277D32701C1EB00332FEA /* GetUserProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B277D22701C1EB00332FEA /* GetUserProfileUseCase.swift */; };
@@ -236,6 +237,7 @@
 		249042EF26D5042D00E970B6 /* SystemImageName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemImageName.swift; sourceTree = "<group>"; };
 		2497356026D34F3200177A7C /* SideMenuActionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionsView.swift; sourceTree = "<group>"; };
 		2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionButtonStyle.swift; sourceTree = "<group>"; };
+		249D8085270AFD88000775BC /* UserProfileViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewModelSpec.swift; sourceTree = "<group>"; };
 		24AB4A652706C4010067CD0D /* ObservableType+Void.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ObservableType+Void.swift"; sourceTree = "<group>"; };
 		24AB4A67270AE58F0067CD0D /* UserProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewModel.swift; sourceTree = "<group>"; };
 		24B277D22701C1EB00332FEA /* GetUserProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUserProfileUseCase.swift; sourceTree = "<group>"; };
@@ -563,6 +565,14 @@
 				249042E526D4D14F00E970B6 /* SignupViewModel.swift */,
 			);
 			path = Signup;
+			sourceTree = "<group>";
+		};
+		249D8084270AFD66000775BC /* UserProfile */ = {
+			isa = PBXGroup;
+			children = (
+				249D8085270AFD88000775BC /* UserProfileViewModelSpec.swift */,
+			);
+			path = UserProfile;
 			sourceTree = "<group>";
 		};
 		24AB4A642706C3EA0067CD0D /* Rx */ = {
@@ -1064,6 +1074,7 @@
 				2D79A8FA26EF4A70007B81D1 /* Feeds */,
 				24F3D7BC26DE041F00DE2420 /* Login */,
 				246B387726F8A7BD003173FD /* SideMenuHeader */,
+				249D8084270AFD66000775BC /* UserProfile */,
 			);
 			path = Modules;
 			sourceTree = "<group>";
@@ -1999,6 +2010,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				249D8086270AFD88000775BC /* UserProfileViewModelSpec.swift in Sources */,
 				2D87823126EB3C110080FEF6 /* FileResource+Decode.swift in Sources */,
 				2D979C322703034C0084A3F8 /* GetCreatedArticlesUseCaseSpec.swift in Sources */,
 				2D46FAF326F8618D005DD323 /* FeedRowViewModelSpec.swift in Sources */,

--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		2497356126D34F3200177A7C /* SideMenuActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2497356026D34F3200177A7C /* SideMenuActionsView.swift */; };
 		2497356326D35BBD00177A7C /* MenuOptionButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */; };
 		24AB4A662706C4010067CD0D /* ObservableType+Void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AB4A652706C4010067CD0D /* ObservableType+Void.swift */; };
+		24AB4A68270AE58F0067CD0D /* UserProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AB4A67270AE58F0067CD0D /* UserProfileViewModel.swift */; };
 		24B277D32701C1EB00332FEA /* GetUserProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B277D22701C1EB00332FEA /* GetUserProfileUseCase.swift */; };
 		24B277D62701C31100332FEA /* GetUserProfileUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B277D52701C31100332FEA /* GetUserProfileUseCaseSpec.swift */; };
 		24B277DC2701C79400332FEA /* APIProfileResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B277DB2701C79400332FEA /* APIProfileResponse+Dummy.swift */; };
@@ -236,6 +237,7 @@
 		2497356026D34F3200177A7C /* SideMenuActionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionsView.swift; sourceTree = "<group>"; };
 		2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionButtonStyle.swift; sourceTree = "<group>"; };
 		24AB4A652706C4010067CD0D /* ObservableType+Void.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ObservableType+Void.swift"; sourceTree = "<group>"; };
+		24AB4A67270AE58F0067CD0D /* UserProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewModel.swift; sourceTree = "<group>"; };
 		24B277D22701C1EB00332FEA /* GetUserProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUserProfileUseCase.swift; sourceTree = "<group>"; };
 		24B277D52701C31100332FEA /* GetUserProfileUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUserProfileUseCaseSpec.swift; sourceTree = "<group>"; };
 		24B277DB2701C79400332FEA /* APIProfileResponse+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIProfileResponse+Dummy.swift"; sourceTree = "<group>"; };
@@ -414,6 +416,7 @@
 			children = (
 				240E217F26FC361000EFC3B5 /* UserProfileView.swift */,
 				24FB783C26FC3A80007534BE /* UserProfileView+UIModel.swift */,
+				24AB4A67270AE58F0067CD0D /* UserProfileViewModel.swift */,
 			);
 			path = UserProfile;
 			sourceTree = "<group>";
@@ -1231,8 +1234,8 @@
 			isa = PBXGroup;
 			children = (
 				2D9032CF26F04D96005CA3F5 /* FeedDetailView.swift */,
-				2DB31D4D26F18EAB007254B9 /* FeedDetailViewModel.swift */,
 				2D34F40E26FAD8C400C99C6C /* FeedDetailView+UIModel.swift */,
+				2DB31D4D26F18EAB007254B9 /* FeedDetailViewModel.swift */,
 			);
 			path = FeedDetail;
 			sourceTree = "<group>";
@@ -1906,6 +1909,7 @@
 				2D9032D026F04D96005CA3F5 /* FeedDetailView.swift in Sources */,
 				2459B31926D74E5100ABCE61 /* APIUserResponse.swift in Sources */,
 				249042E826D4D14F00E970B6 /* SignupView.swift in Sources */,
+				24AB4A68270AE58F0067CD0D /* UserProfileViewModel.swift in Sources */,
 				241F5B852701A9F8002E13FC /* UserRepository.swift in Sources */,
 				2DBE36B126C3B33700DA3511 /* SideMenuView.swift in Sources */,
 				24204CA026D625D300534314 /* SideMenuActionsViewModel.swift in Sources */,

--- a/NimbleMedium/Resources/en.lproj/Localizable.strings
+++ b/NimbleMedium/Resources/en.lproj/Localizable.strings
@@ -43,3 +43,4 @@
 "signup.title" = "Signup";
 
 "userProfile.title" = "Profile";
+"userProfile.username.unknown" = "Unknown User";

--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -110,5 +110,8 @@ extension Resolver: ResolverRegistering {
         register { SideMenuHeaderViewModel() }.implements(SideMenuHeaderViewModelProtocol.self).scope(.cached)
         register { SideMenuViewModel() }.implements(SideMenuViewModelProtocol.self).scope(.cached)
         register { SignupViewModel() }.implements(SignupViewModelProtocol.self).scope(.cached)
+        register { _, args in
+            UserProfileViewModel(username: args.get())
+        }.implements(UserProfileViewModelProtocol.self)
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileView+UIModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileView+UIModel.swift
@@ -13,7 +13,5 @@ extension UserProfileView {
 
          let avatarURL: URL?
          let username: String
-
-         // TODO: Add more attributes in other feature tasks
      }
  }

--- a/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileView.swift
@@ -13,6 +13,8 @@ import ToastUI
 struct UserProfileView: View {
 
     @State private var uiModel: UIModel?
+    @State private var errorMessage = ""
+    @State private var errorToast = false
 
     @ObservedViewModel var viewModel: UserProfileViewModelProtocol
 
@@ -32,7 +34,16 @@ struct UserProfileView: View {
         .navigationTitle(Localizable.userProfileTitle())
         .modifier(NavigationBarPrimaryStyle())
         .onAppear { viewModel.input.getUserProfile() }
+        .toast(isPresented: $errorToast, dismissAfter: 3.0) {
+            ToastView(errorMessage) { } background: {
+                Color.clear
+            }
+        }
         .bind(viewModel.output.userProfileUIModel, to: _uiModel)
+        .onReceive(viewModel.output.errorMessage) { _ in
+            errorMessage = Localizable.errorGeneric()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { errorToast.toggle() }
+        }
     }
 
     var profileHeader: some View {
@@ -46,7 +57,7 @@ struct UserProfileView: View {
             } else {
                 defaultAvatar
             }
-            Text(uiModel?.username ?? Localizable.defaultUsernameValue())
+            Text(uiModel?.username ?? Localizable.userProfileUsernameUnknown())
                 .foregroundColor(.white)
                 .fontWeight(.bold)
                 .lineLimit(2)

--- a/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileView.swift
@@ -5,16 +5,18 @@
 //  Created by Minh Pham on 23/09/2021.
 //
 
-import Foundation
-
+import Resolver
 import SDWebImageSwiftUI
 import SwiftUI
 import ToastUI
 
 struct UserProfileView: View {
 
-    // TODO: Update to real data in integrate task
-    @State private var uiModel: UIModel = UIModel(avatarURL: nil, username: Localizable.defaultUsernameValue())
+    @State private var uiModel: UIModel?
+
+    @ObservedViewModel var viewModel: UserProfileViewModelProtocol
+
+    private let username: String?
 
     var body: some View {
         ScrollView(.vertical) {
@@ -29,11 +31,13 @@ struct UserProfileView: View {
         }
         .navigationTitle(Localizable.userProfileTitle())
         .modifier(NavigationBarPrimaryStyle())
+        .onAppear { viewModel.input.getUserProfile() }
+        .bind(viewModel.output.userProfileUIModel, to: _uiModel)
     }
 
     var profileHeader: some View {
         VStack(alignment: .center, spacing: 0.0) {
-            if let url = uiModel.avatarURL {
+            if let url = uiModel?.avatarURL {
                 WebImage(url: url)
                     .placeholder { defaultAvatar }
                     .resizable()
@@ -42,7 +46,7 @@ struct UserProfileView: View {
             } else {
                 defaultAvatar
             }
-            Text(uiModel.username)
+            Text(uiModel?.username ?? Localizable.defaultUsernameValue())
                 .foregroundColor(.white)
                 .fontWeight(.bold)
                 .lineLimit(2)
@@ -56,6 +60,15 @@ struct UserProfileView: View {
             .resizable()
             .frame(width: 120.0, height: 120.0)
             .clipShape(Circle())
+    }
+
+    init(username: String? = nil) {
+        self.username = username
+
+        viewModel = Resolver.resolve(
+            UserProfileViewModelProtocol.self,
+            args: username
+        )
     }
 }
 

--- a/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileViewModel.swift
@@ -1,0 +1,95 @@
+//
+//  UserProfileViewModel.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 04/10/2021.
+//
+
+import Resolver
+import RxCocoa
+import RxSwift
+
+protocol UserProfileViewModelInput {
+
+    func getUserProfile()
+}
+
+protocol UserProfileViewModelOutput {
+
+    var userProfileUIModel: Driver<UserProfileView.UIModel?> { get }
+    var errorMessage: Signal<String> { get }
+}
+
+protocol UserProfileViewModelProtocol: ObservableViewModel {
+
+    var input: UserProfileViewModelInput { get }
+    var output: UserProfileViewModelOutput { get }
+}
+
+final class UserProfileViewModel: ObservableObject, UserProfileViewModelProtocol {
+
+    private let disposeBag = DisposeBag()
+    private let getUserProfileTrigger = PublishRelay<String>()
+    private let username: String?
+
+    var input: UserProfileViewModelInput { self }
+    var output: UserProfileViewModelOutput { self }
+
+    @PublishRelayProperty var didGetUserProfile: Signal<Void>
+    @PublishRelayProperty var errorMessage: Signal<String>
+
+    @BehaviorRelayProperty(nil) var userProfileUIModel: Driver<UserProfileView.UIModel?>
+
+    @Injected var getUserProfileUseCase: GetUserProfileUseCaseProtocol
+
+    init(username: String?) {
+        self.username = username
+        
+        getUserProfileTrigger
+            .withUnretained(self)
+            .flatMapLatest { owner, input in owner.getUserProfileTrigger(owner: owner, username: input) }
+            .subscribe()
+            .disposed(by: disposeBag)
+    }
+}
+
+extension UserProfileViewModel: UserProfileViewModelInput {
+
+    func getUserProfile() {
+        if let username = username {
+            getUserProfileTrigger.accept(username)
+        } else {
+            // TODO: Handle loading current user profile in integrate task
+        }
+    }
+}
+
+extension UserProfileViewModel: UserProfileViewModelOutput { }
+
+private extension UserProfileViewModel {
+
+    func getUserProfileTrigger(owner: UserProfileViewModel, username: String) -> Observable<Void> {
+        getUserProfileUseCase
+            .execute(username: username)
+            .do(
+                onSuccess: {
+                    owner.$userProfileUIModel.accept(owner.generateUIModel(from: $0))
+                },
+                onError: { error in owner.$errorMessage.accept(error.detail) }
+            )
+            .asObservable()
+            .mapToVoid()
+            .catchAndReturn(())
+    }
+
+    func generateUIModel(from profile: Profile) -> UserProfileView.UIModel {
+        var username = Localizable.defaultUsernameValue()
+        if !profile.username.isEmpty {
+            username = profile.username
+        }
+        return UserProfileView.UIModel(
+            avatarURL: try? profile.image?.asURL(),
+            username: username
+        )
+    }
+}

--- a/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileViewModel.swift
@@ -75,7 +75,10 @@ private extension UserProfileViewModel {
                 onSuccess: {
                     owner.$userProfileUIModel.accept(owner.generateUIModel(from: $0))
                 },
-                onError: { error in owner.$errorMessage.accept(error.detail) }
+                onError: { error in
+                    owner.$errorMessage.accept(error.detail)
+                    owner.$userProfileUIModel.accept(nil)
+                }
             )
             .asObservable()
             .mapToVoid()

--- a/NimbleMedium/Sources/Presentation/Views/AuthorView.swift
+++ b/NimbleMedium/Sources/Presentation/Views/AuthorView.swift
@@ -28,7 +28,7 @@ struct AuthorView: View {
             }
             VStack(alignment: .leading) {
                 NavigationLink(
-                    destination: UserProfileView(),
+                    destination: UserProfileView(username: authorName),
                     label: {
                         Text(authorName)
                             .foregroundColor(authorNameColor)

--- a/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
+++ b/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
@@ -39,6 +39,7 @@ extension Resolver {
         }
         .implements(GetCurrentSessionUseCaseProtocol.self)
         Resolver.mock.register { GetListArticlesUseCaseProtocolMock() }.implements(GetListArticlesUseCaseProtocol.self)
+        Resolver.mock.register { GetUserProfileUseCaseProtocolMock() }.implements(GetUserProfileUseCaseProtocol.self)
         Resolver.mock.register { LoginUseCaseProtocolMock() }.implements(LoginUseCaseProtocol.self)
     }
 

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/UserProfile/UserProfileViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/UserProfile/UserProfileViewModelSpec.swift
@@ -1,0 +1,84 @@
+//
+//  UserProfileViewModelSpec.swift
+//  NimbleMediumTests
+//
+//  Created by Minh Pham on 04/10/2021.
+//
+
+import Quick
+import Nimble
+import RxNimble
+import RxSwift
+import RxTest
+import Resolver
+
+@testable import NimbleMedium
+
+final class UserProfileViewModelSpec: QuickSpec {
+
+    @LazyInjected var getUserProfileUseCase: GetUserProfileUseCaseProtocolMock
+
+    override func spec() {
+        var viewModel: UserProfileViewModelProtocol!
+        var scheduler: TestScheduler!
+        var disposeBag: DisposeBag!
+
+        describe("a UserProfileViewModel") {
+
+            beforeEach {
+                Resolver.registerMockServices()
+                viewModel = UserProfileViewModel(username: "username")
+                scheduler = TestScheduler(initialClock: 0)
+                disposeBag = DisposeBag()
+            }
+
+            describe("its getUserProfile() call") {
+
+                context("when GetUserProfileUseCase return success") {
+
+                    let inputProfile = APIProfileResponse.dummy.profile
+
+                    beforeEach {
+                        self.getUserProfileUseCase.executeUsernameReturnValue =
+                            .just(inputProfile, on: scheduler, at: 10)
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.getUserProfile()
+                        }
+                    }
+
+                    it("returns output userProfileUIModel with correct value") {
+                        let expectedValue = UserProfileView.UIModel(
+                            avatarURL: try? inputProfile.image?.asURL(),
+                            username: inputProfile.username
+                        )
+
+                        expect(viewModel.output.userProfileUIModel)
+                            .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                                .next(0, nil),
+                                .next(10, expectedValue)
+                            ]
+                    }
+                }
+
+                context("when GetUserProfileUseCase return failure") {
+
+                    beforeEach {
+                        self.getUserProfileUseCase.executeUsernameReturnValue =
+                            .error(TestError.mock, on: scheduler, at: 10)
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.getUserProfile()
+                        }
+                    }
+
+                    it("returns output errorMessage with signal") {
+                        expect(viewModel.output.errorMessage)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .notTo(beEmpty())
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolved #64

## What happened

When the users don't login to the app yet, they will still be able to view other author profile by selecting the author region in the `Article Details` screen.

## Insight

- [x] Get the other author user profile from the server and populate data for the current user in the `Profile` screen, including the user avatar url and the username.
- [x] Show a native loading indicator in the middle of the screen while loading the author profile info.
- [x] When there is an error while loading the other author profile, show a temporary toast message with text: `Something went wrong. Please try again later.`
- [x] If the app is unable to loadthe other author profile, show the app default avatar image view and the default username with text: `Unknown User`.

## Proof Of Work

https://user-images.githubusercontent.com/70877098/135831234-49d5579a-9df0-4f41-812c-4263a572161f.mov

Unit tests added:

<img width="984" alt="Screen Shot 2021-10-04 at 16 40 36" src="https://user-images.githubusercontent.com/70877098/135829590-0a96eddb-a42f-4306-b72c-666e144c0b7a.png">

With coverage report:

<img width="984" alt="Screen Shot 2021-10-04 at 16 41 43" src="https://user-images.githubusercontent.com/70877098/135829618-9828d660-e0f3-4d28-9de2-c23cfb807172.png">


