### PR TITLE
[#57] As a user, I can view my own profile details

### DIFF
--- a/NimbleMedium/Sources/Domain/Repositories/User/UserSessionRepositoryProtocol.swift
+++ b/NimbleMedium/Sources/Domain/Repositories/User/UserSessionRepositoryProtocol.swift
@@ -7,6 +7,7 @@
 
 import RxSwift
 
+// sourcery: AutoMockable
 protocol UserSessionRepositoryProtocol: AnyObject {
 
     func saveUser(_ user: User) -> Completable

--- a/NimbleMedium/Sources/Domain/UseCases/User/GetCurrentUserUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/User/GetCurrentUserUseCase.swift
@@ -16,14 +16,24 @@ protocol GetCurrentUserUseCaseProtocol: AnyObject {
 final class GetCurrentUserUseCase: GetCurrentUserUseCaseProtocol {
 
     private let authRepository: AuthRepositoryProtocol
+    private let userSessionRepository: UserSessionRepositoryProtocol
 
     init(
-        authRepository: AuthRepositoryProtocol
+        authRepository: AuthRepositoryProtocol,
+        userSessionRepository: UserSessionRepository
     ) {
         self.authRepository = authRepository
+        self.userSessionRepository = userSessionRepository
     }
 
     func execute() -> Single<User> {
-        authRepository.getCurrentUser()
+        authRepository
+            .getCurrentUser()
+            .asObservable()
+            .withUnretained(self)
+            .flatMapLatest { owner, user -> Single<User> in
+                owner.userSessionRepository.saveUser(user).andThen(.just(user))
+            }
+            .asSingle()
     }
 }

--- a/NimbleMedium/Sources/Domain/UseCases/User/GetCurrentUserUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/User/GetCurrentUserUseCase.swift
@@ -20,7 +20,7 @@ final class GetCurrentUserUseCase: GetCurrentUserUseCaseProtocol {
 
     init(
         authRepository: AuthRepositoryProtocol,
-        userSessionRepository: UserSessionRepository
+        userSessionRepository: UserSessionRepositoryProtocol
     ) {
         self.authRepository = authRepository
         self.userSessionRepository = userSessionRepository

--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -45,6 +45,7 @@ extension Resolver: ResolverRegistering {
         }.implements(UserSessionRepositoryProtocol.self)
     }
 
+    // swiftlint:disable function_body_length
     private static func registerUseCases() {
         register {
             GetArticleCommentsUseCase(articleCommentRepository: resolve())
@@ -56,7 +57,10 @@ extension Resolver: ResolverRegistering {
             GetCurrentSessionUseCase(userSessionRepository: resolve())
         }.implements(GetCurrentSessionUseCaseProtocol.self)
         register {
-            GetCurrentUserUseCase(authRepository: resolve())
+            GetCurrentUserUseCase(
+                authRepository: resolve(),
+                userSessionRepository: resolve()
+            )
         }.implements(GetCurrentUserUseCaseProtocol.self)
         register {
             GetListArticlesUseCase(articleRepository: resolve())

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuMain/SideMenuViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuMain/SideMenuViewModel.swift
@@ -45,6 +45,13 @@ extension SideMenuViewModel: SideMenuViewModelInput {
                 self.$didSelectMenuOption.accept(())
             }
             .disposed(by: disposeBag)
+
+        sideMenuActionsViewModel.output.didSelectMyProfileOption.asObservable()
+            .withUnretained(self)
+            .bind { _ in
+                self.$didSelectMenuOption.accept(())
+            }
+            .disposed(by: disposeBag)
         
         sideMenuActionsViewModel.output.didSelectSignupOption.asObservable()
             .withUnretained(self)

--- a/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileViewModel.swift
@@ -44,7 +44,7 @@ final class UserProfileViewModel: ObservableObject, UserProfileViewModelProtocol
     @Injected var getCurrentUserUseCase: GetCurrentUserUseCaseProtocol
     @Injected var getUserProfileUseCase: GetUserProfileUseCaseProtocol
 
-    init(username: String?) {
+    init(username: String? = nil) {
         self.username = username
 
         getCurrentUserTrigger

--- a/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
+++ b/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
@@ -38,6 +38,7 @@ extension Resolver {
             GetCurrentSessionUseCaseProtocolMock()
         }
         .implements(GetCurrentSessionUseCaseProtocol.self)
+        Resolver.mock.register { GetCurrentUserUseCaseProtocolMock() }.implements(GetCurrentUserUseCaseProtocol.self)
         Resolver.mock.register { GetListArticlesUseCaseProtocolMock() }.implements(GetListArticlesUseCaseProtocol.self)
         Resolver.mock.register { GetUserProfileUseCaseProtocolMock() }.implements(GetUserProfileUseCaseProtocol.self)
         Resolver.mock.register { LoginUseCaseProtocolMock() }.implements(LoginUseCaseProtocol.self)

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/UserProfile/UserProfileViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/UserProfile/UserProfileViewModelSpec.swift
@@ -16,6 +16,7 @@ import Resolver
 
 final class UserProfileViewModelSpec: QuickSpec {
 
+    @LazyInjected var getCurrentUserUseCase: GetCurrentUserUseCaseProtocolMock
     @LazyInjected var getUserProfileUseCase: GetUserProfileUseCaseProtocolMock
 
     override func spec() {
@@ -27,55 +28,113 @@ final class UserProfileViewModelSpec: QuickSpec {
 
             beforeEach {
                 Resolver.registerMockServices()
-                viewModel = UserProfileViewModel(username: "username")
                 scheduler = TestScheduler(initialClock: 0)
                 disposeBag = DisposeBag()
             }
 
             describe("its getUserProfile() call") {
 
-                context("when GetUserProfileUseCase return success") {
-
-                    let inputProfile = APIProfileResponse.dummy.profile
+                context("when there is a valid username") {
 
                     beforeEach {
-                        self.getUserProfileUseCase.executeUsernameReturnValue =
-                            .just(inputProfile, on: scheduler, at: 10)
+                        viewModel = UserProfileViewModel(username: "username")
+                    }
 
-                        scheduler.scheduleAt(5) {
-                            viewModel.input.getUserProfile()
+                    context("when GetUserProfileUseCase return success") {
+
+                        let inputProfile = APIProfileResponse.dummy.profile
+
+                        beforeEach {
+                            self.getUserProfileUseCase.executeUsernameReturnValue =
+                                .just(inputProfile, on: scheduler, at: 10)
+
+                            scheduler.scheduleAt(5) {
+                                viewModel.input.getUserProfile()
+                            }
+                        }
+
+                        it("returns output userProfileUIModel with correct value") {
+                            let expectedValue = UserProfileView.UIModel(
+                                avatarURL: try? inputProfile.image?.asURL(),
+                                username: inputProfile.username
+                            )
+
+                            expect(viewModel.output.userProfileUIModel)
+                                .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                                    .next(0, nil),
+                                    .next(10, expectedValue)
+                                ]
                         }
                     }
 
-                    it("returns output userProfileUIModel with correct value") {
-                        let expectedValue = UserProfileView.UIModel(
-                            avatarURL: try? inputProfile.image?.asURL(),
-                            username: inputProfile.username
-                        )
+                    context("when GetUserProfileUseCase return failure") {
 
-                        expect(viewModel.output.userProfileUIModel)
-                            .events(scheduler: scheduler, disposeBag: disposeBag) == [
-                                .next(0, nil),
-                                .next(10, expectedValue)
-                            ]
+                        beforeEach {
+                            self.getUserProfileUseCase.executeUsernameReturnValue =
+                                .error(TestError.mock, on: scheduler, at: 10)
+
+                            scheduler.scheduleAt(5) {
+                                viewModel.input.getUserProfile()
+                            }
+                        }
+
+                        it("returns output errorMessage with signal") {
+                            expect(viewModel.output.errorMessage)
+                                .events(scheduler: scheduler, disposeBag: disposeBag)
+                                .notTo(beEmpty())
+                        }
                     }
                 }
 
-                context("when GetUserProfileUseCase return failure") {
+                context("when there is no username provided") {
 
                     beforeEach {
-                        self.getUserProfileUseCase.executeUsernameReturnValue =
-                            .error(TestError.mock, on: scheduler, at: 10)
+                        viewModel = UserProfileViewModel()
+                    }
 
-                        scheduler.scheduleAt(5) {
-                            viewModel.input.getUserProfile()
+                    context("when GetCurrentUserUseCase return success") {
+
+                        let inputUser = APIUserResponse.dummy.user
+
+                        beforeEach {
+                            self.getCurrentUserUseCase.executeReturnValue =
+                                .just(inputUser, on: scheduler, at: 10)
+
+                            scheduler.scheduleAt(5) {
+                                viewModel.input.getUserProfile()
+                            }
+                        }
+
+                        it("returns output userProfileUIModel with correct value") {
+                            let expectedValue = UserProfileView.UIModel(
+                                avatarURL: try? inputUser.image?.asURL(),
+                                username: inputUser.username
+                            )
+
+                            expect(viewModel.output.userProfileUIModel)
+                                .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                                    .next(0, nil),
+                                    .next(10, expectedValue)
+                                ]
                         }
                     }
 
-                    it("returns output errorMessage with signal") {
-                        expect(viewModel.output.errorMessage)
-                            .events(scheduler: scheduler, disposeBag: disposeBag)
-                            .notTo(beEmpty())
+                    context("when GetCurrentUserUseCase return failure") {
+
+                        beforeEach {
+                            self.getCurrentUserUseCase.executeReturnValue =
+                                .error(TestError.mock, on: scheduler, at: 10)
+
+                            scheduler.scheduleAt(5) {
+                                viewModel.input.getUserProfile()
+                            }
+                        }
+
+                        it("returns output errorMessage with signal") {
+                            expect(viewModel.output.errorMessage)
+                                .events(scheduler: scheduler, disposeBag: disposeBag)
+                                .notTo(beEmpty())
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Resolved #57

## What happened

When the users logged in the application successfully, they will be able to view their profile details with a `My Profile` option in the left menu from `Home` Screen.

## Insight

- [x] Get the current user profile from the server and populate data for the current user in the `My Profile` screen, including the user avatar url and the username.
- [x] Stored the user profile information in memory cache for later usage in the session.
- [x] Show a native loading indicator in the middle of the screen while loading the current user info.
- [x] When there is an error while loading the current user, show a temporary toast message with text: `Something went wrong. Please try again later.`
- [x] If the app is unable to load the current user, show the default `Smiley` avatar image view and the default username with text: `Unknown User`.

## Proof Of Work

https://user-images.githubusercontent.com/70877098/136324407-f4474ddc-748a-4209-b528-5db0f0bee491.MP4


