### PR TITLE
[#167] Fix: 1 nokogiri vulnerability found in Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gem "fastlane"
 gem "cocoapods", "1.10.2"
 gem 'slather'
-
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,6 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-firebase_app_distribution (0.3.1)
     ffi (1.15.4)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -286,7 +285,6 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (= 1.10.2)
   fastlane
-  fastlane-plugin-firebase_app_distribution
   slather
 
 BUNDLED WITH


### PR DESCRIPTION
Resolved #167

## What happened

1 nokogiri vulnerability found in Gemfile.lock. Details about the vulnerability issue can be found here:

https://github.com/nimblehq/nimble-medium-ios/security/dependabot/Gemfile.lock/nokogiri/open

## Insight

- Fix the Gem file for the Dependency bot to work.

## Proof Of Work

No visual change, just under the hood optimization 🛠
