### PR TITLE
[#39] As a user, I can update my profile from the left menu header

### DIFF
--- a/NimbleMedium/Sources/Constants/SystemImageName.swift
+++ b/NimbleMedium/Sources/Constants/SystemImageName.swift
@@ -6,6 +6,7 @@
 //
 
 enum SystemImageName: String {
-    case xmark
     case chevronBackward = "chevron.backward"
+    case squareAndPencil = "square.and.pencil"
+    case xmark
 }

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuHeader/SideMenuHeaderView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuHeader/SideMenuHeaderView.swift
@@ -48,6 +48,9 @@ struct SideMenuHeaderView: View {
 
     func authenticatedMenuHeader(uiModel: UIModel) -> some View {
         VStack(alignment: .center) {
+            Spacer()
+            Spacer()
+            Spacer()
             AvatarView(url: uiModel.avatarURL)
                 .size(100.0)
                 .circle()
@@ -57,6 +60,18 @@ struct SideMenuHeaderView: View {
                 .lineLimit(2)
                 .multilineTextAlignment(.center)
                 .padding()
+            Spacer()
+            HStack {
+                Spacer()
+                Button(
+                    action: {
+                        // TODO: Handle edit profile button in integrate task
+                    },
+                    label: { Image(systemName: SystemImageName.squareAndPencil.rawValue) }
+                )
+                    .foregroundColor(.white)
+                    .padding()
+            }
         }
     }
 }


### PR DESCRIPTION
Resolved #39

## What happened

Once the users logged in the application successfully, they can edit their profile from the menu header if needed.

## Insight

- [x] Add the `Edit Profile` button with no text in the bottom right corner of the header view container.
- [x] Set the tint of the `Edit Profile` button to white for matching with our green and white theme.
- [x] Use the edit profile icon from Apple's default resource.

## Proof Of Work

<img src="https://user-images.githubusercontent.com/70877098/136747719-777eb569-8a35-40e7-b2f8-ac26843332ce.jpeg" width="300">

