### PR TITLE
[#42] As a user, I can logout from the left menu

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		240E218026FC361000EFC3B5 /* UserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 240E217F26FC361000EFC3B5 /* UserProfileView.swift */; };
 		2410D4A127041837009B4A95 /* AuthenticatedInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2410D4A027041837009B4A95 /* AuthenticatedInterceptor.swift */; };
+		241A5A252713FA9B00BC33F1 /* LogoutUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241A5A242713FA9B00BC33F1 /* LogoutUseCase.swift */; };
 		241B4EEA26D3B3F4000409CC /* SideMenuActionItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */; };
 		241B99DC26DF23030041207F /* AutoMockable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B99DB26DF23030041207F /* AutoMockable.generated.swift */; };
 		241B99DE26DF34720041207F /* SignupUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B99DD26DF34720041207F /* SignupUseCase.swift */; };
@@ -203,6 +204,7 @@
 		21851292A064EB97674233A2 /* Pods-NimbleMediumTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleMediumTests.staging.xcconfig"; path = "Target Support Files/Pods-NimbleMediumTests/Pods-NimbleMediumTests.staging.xcconfig"; sourceTree = "<group>"; };
 		240E217F26FC361000EFC3B5 /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
 		2410D4A027041837009B4A95 /* AuthenticatedInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedInterceptor.swift; sourceTree = "<group>"; };
+		241A5A242713FA9B00BC33F1 /* LogoutUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutUseCase.swift; sourceTree = "<group>"; };
 		241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionItemView.swift; sourceTree = "<group>"; };
 		241B99DB26DF23030041207F /* AutoMockable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoMockable.generated.swift; sourceTree = "<group>"; };
 		241B99DD26DF34720041207F /* SignupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupUseCase.swift; sourceTree = "<group>"; };
@@ -625,6 +627,7 @@
 			children = (
 				2459B32726D751E300ABCE61 /* LoginUseCase.swift */,
 				241B99DD26DF34720041207F /* SignupUseCase.swift */,
+				241A5A242713FA9B00BC33F1 /* LogoutUseCase.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -2053,6 +2056,7 @@
 				24204C9E26D5289900534314 /* Background.swift in Sources */,
 				2DEF1F9826E6055A00EB93CC /* GetListArticlesUseCase.swift in Sources */,
 				24B277D32701C1EB00332FEA /* GetUserProfileUseCase.swift in Sources */,
+				241A5A252713FA9B00BC33F1 /* LogoutUseCase.swift in Sources */,
 				248E13A926F054AD00439BCC /* Resolver+Injection.swift in Sources */,
 				2DEF1F9A26E6092500EB93CC /* APIArticlesResponse.swift in Sources */,
 				241F5B8B2701BEFB002E13FC /* UserRepositoryProtocol.swift in Sources */,

--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		240E218026FC361000EFC3B5 /* UserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 240E217F26FC361000EFC3B5 /* UserProfileView.swift */; };
 		2410D4A127041837009B4A95 /* AuthenticatedInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2410D4A027041837009B4A95 /* AuthenticatedInterceptor.swift */; };
 		241A5A252713FA9B00BC33F1 /* LogoutUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241A5A242713FA9B00BC33F1 /* LogoutUseCase.swift */; };
+		241A5A282714206E00BC33F1 /* LogoutUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241A5A272714206E00BC33F1 /* LogoutUseCaseSpec.swift */; };
 		241B4EEA26D3B3F4000409CC /* SideMenuActionItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */; };
 		241B99DC26DF23030041207F /* AutoMockable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B99DB26DF23030041207F /* AutoMockable.generated.swift */; };
 		241B99DE26DF34720041207F /* SignupUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B99DD26DF34720041207F /* SignupUseCase.swift */; };
@@ -47,6 +48,7 @@
 		2477173B2704336A00BF13F2 /* GetCurrentUserUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2477173A2704336A00BF13F2 /* GetCurrentUserUseCaseSpec.swift */; };
 		2477173D27043E7900BF13F2 /* APIUserResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2477173C27043E7900BF13F2 /* APIUserResponse+Dummy.swift */; };
 		2477173F27043EAB00BF13F2 /* user.json in Resources */ = {isa = PBXBuildFile; fileRef = 2477173E27043EAB00BF13F2 /* user.json */; };
+		247CD0F027142A13002D90D1 /* SideMenuActionsViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247CD0EF27142A13002D90D1 /* SideMenuActionsViewModelSpec.swift */; };
 		248E13A926F054AD00439BCC /* Resolver+Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248E13A826F054AD00439BCC /* Resolver+Injection.swift */; };
 		248E13AC26F054FD00439BCC /* Resolver in Frameworks */ = {isa = PBXBuildFile; productRef = 248E13AB26F054FD00439BCC /* Resolver */; };
 		248E13B426F07F5800439BCC /* Resolver+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248E13B326F07F5800439BCC /* Resolver+Tests.swift */; };
@@ -205,6 +207,7 @@
 		240E217F26FC361000EFC3B5 /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
 		2410D4A027041837009B4A95 /* AuthenticatedInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedInterceptor.swift; sourceTree = "<group>"; };
 		241A5A242713FA9B00BC33F1 /* LogoutUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutUseCase.swift; sourceTree = "<group>"; };
+		241A5A272714206E00BC33F1 /* LogoutUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutUseCaseSpec.swift; sourceTree = "<group>"; };
 		241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionItemView.swift; sourceTree = "<group>"; };
 		241B99DB26DF23030041207F /* AutoMockable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoMockable.generated.swift; sourceTree = "<group>"; };
 		241B99DD26DF34720041207F /* SignupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupUseCase.swift; sourceTree = "<group>"; };
@@ -241,6 +244,7 @@
 		2477173A2704336A00BF13F2 /* GetCurrentUserUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentUserUseCaseSpec.swift; sourceTree = "<group>"; };
 		2477173C27043E7900BF13F2 /* APIUserResponse+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIUserResponse+Dummy.swift"; sourceTree = "<group>"; };
 		2477173E27043EAB00BF13F2 /* user.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = user.json; sourceTree = "<group>"; };
+		247CD0EF27142A13002D90D1 /* SideMenuActionsViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionsViewModelSpec.swift; sourceTree = "<group>"; };
 		248E13A826F054AD00439BCC /* Resolver+Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Resolver+Injection.swift"; sourceTree = "<group>"; };
 		248E13B326F07F5800439BCC /* Resolver+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Resolver+Tests.swift"; sourceTree = "<group>"; };
 		249042E526D4D14F00E970B6 /* SignupViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignupViewModel.swift; sourceTree = "<group>"; };
@@ -457,6 +461,14 @@
 			path = Interceptors;
 			sourceTree = "<group>";
 		};
+		241A5A262714202C00BC33F1 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				241A5A272714206E00BC33F1 /* LogoutUseCaseSpec.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
 		24204CA326D6465C00534314 /* SideMenuActions */ = {
 			isa = PBXGroup;
 			children = (
@@ -566,6 +578,23 @@
 				246B387826F8A7D7003173FD /* SideMenuHeaderViewModelSpec.swift */,
 			);
 			path = SideMenuHeader;
+			sourceTree = "<group>";
+		};
+		247CD0ED271429DB002D90D1 /* SideMenu */ = {
+			isa = PBXGroup;
+			children = (
+				247CD0EE271429F4002D90D1 /* SideMenuActions */,
+				246B387726F8A7BD003173FD /* SideMenuHeader */,
+			);
+			path = SideMenu;
+			sourceTree = "<group>";
+		};
+		247CD0EE271429F4002D90D1 /* SideMenuActions */ = {
+			isa = PBXGroup;
+			children = (
+				247CD0EF27142A13002D90D1 /* SideMenuActionsViewModelSpec.swift */,
+			);
+			path = SideMenuActions;
 			sourceTree = "<group>";
 		};
 		248E13B126F067A300439BCC /* Injection */ = {
@@ -1123,6 +1152,7 @@
 		2D72E49326C21C2F00861239 /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
+				241A5A262714202C00BC33F1 /* Auth */,
 				24B277D72701C31700332FEA /* Article */,
 				24B277D82701C32600332FEA /* Comment */,
 				24B277D42701C2EE00332FEA /* User */,
@@ -1145,7 +1175,7 @@
 				2DB31D4F26F1960B007254B9 /* ArticleDetail */,
 				2D79A8FA26EF4A70007B81D1 /* Feeds */,
 				24F3D7BC26DE041F00DE2420 /* Login */,
-				246B387726F8A7BD003173FD /* SideMenuHeader */,
+				247CD0ED271429DB002D90D1 /* SideMenu */,
 				249D8084270AFD66000775BC /* UserProfile */,
 			);
 			path = Modules;
@@ -2098,10 +2128,12 @@
 				2D46FAF326F8618D005DD323 /* ArticleRowViewModelSpec.swift in Sources */,
 				2D73312F26F0F3A20052DCC7 /* APIArticleResponse+Dummy.swift in Sources */,
 				2D73313126F0F4800052DCC7 /* GetArticleUseCaseSpec.swift in Sources */,
+				241A5A282714206E00BC33F1 /* LogoutUseCaseSpec.swift in Sources */,
 				2D1A93AC270FFB45003B2011 /* UserProfileFavouritedArticlesTabViewModelSpec.swift in Sources */,
 				2D79A8FC26EF4A7E007B81D1 /* FeedsViewModelSpec.swift in Sources */,
 				2DC224E62702BB4C008382E3 /* GetFavouritedArticlesUseCaseSpec.swift in Sources */,
 				2D29A70D26F44426001EA24F /* ArticleCommentsViewModelSpec.swift in Sources */,
+				247CD0F027142A13002D90D1 /* SideMenuActionsViewModelSpec.swift in Sources */,
 				24F3D7C426DE0FAE00DE2420 /* TestError.swift in Sources */,
 				246B387926F8A7D7003173FD /* SideMenuHeaderViewModelSpec.swift in Sources */,
 				24F3D7BE26DE041F00DE2420 /* LoginViewModelSpec.swift in Sources */,

--- a/NimbleMedium.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NimbleMedium.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/hmlongco/Resolver",
         "state": {
           "branch": null,
-          "revision": "473a53747489e48da848fbec8cc8ee944c28f3b2",
-          "version": "1.4.5"
+          "revision": "609908e0b67911ebf7386609552a48d4ec07958e",
+          "version": "1.4.4"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/SDWebImage/SDWebImage.git",
         "state": {
           "branch": null,
-          "revision": "d6367439527663d2038ca445a3c3c4e4bac40d60",
-          "version": "5.12.0"
+          "revision": "76dd4b49110b8624317fc128e7fa0d8a252018bc",
+          "version": "5.11.1"
         }
       },
       {

--- a/NimbleMedium.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NimbleMedium.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/hmlongco/Resolver",
         "state": {
           "branch": null,
-          "revision": "609908e0b67911ebf7386609552a48d4ec07958e",
-          "version": "1.4.4"
+          "revision": "473a53747489e48da848fbec8cc8ee944c28f3b2",
+          "version": "1.4.5"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/SDWebImage/SDWebImage.git",
         "state": {
           "branch": null,
-          "revision": "76dd4b49110b8624317fc128e7fa0d8a252018bc",
-          "version": "5.11.1"
+          "revision": "d6367439527663d2038ca445a3c3c4e4bac40d60",
+          "version": "5.12.0"
         }
       },
       {

--- a/NimbleMedium/Resources/en.lproj/Localizable.strings
+++ b/NimbleMedium/Resources/en.lproj/Localizable.strings
@@ -6,8 +6,10 @@
   
 */
 
-"action.login" = "Login";
-"action.signup" = "Signup";
+"action.cancel.text" = "Cancel";
+"action.confirm.text" = "Confirm";
+"action.login.text" = "Login";
+"action.signup.text" = "Signup";
 
 "articleDetail.comments.title" = "Go to comments section";
 "articleDetail.fetchFailure.message" = "Unable to load the article";
@@ -35,6 +37,8 @@
 "menu.option.logout" = "Logout";
 "menu.option.myProfile" = "My Profile";
 "menu.option.signup" = "Signup";
+
+"popup.confirmLogout.title" = "Are you sure you want to logout?";
 
 "signup.haveAccount.title" = "Have an account?";
 "signup.textFieldEmail.placeholder" = "Email";

--- a/NimbleMedium/Sources/Data/Repositories/User/UserSessionRepository.swift
+++ b/NimbleMedium/Sources/Data/Repositories/User/UserSessionRepository.swift
@@ -32,10 +32,11 @@ final class UserSessionRepository: UserSessionRepositoryProtocol {
         Completable.create { [weak self] observer in
             do {
                 try self?.keychain.remove(.user)
+                observer(.completed)
             } catch {
                 observer(.error(error))
             }
-            observer(.completed)
+
             return Disposables.create()
         }
     }
@@ -44,10 +45,11 @@ final class UserSessionRepository: UserSessionRepositoryProtocol {
         Completable.create { [weak self] observer in
             do {
                 try self?.keychain.set(CodableUser(user: user), for: .user)
+                observer(.completed)
             } catch {
                 observer(.error(error))
             }
-            observer(.completed)
+
             return Disposables.create()
         }
     }

--- a/NimbleMedium/Sources/Data/Repositories/User/UserSessionRepository.swift
+++ b/NimbleMedium/Sources/Data/Repositories/User/UserSessionRepository.swift
@@ -15,18 +15,6 @@ final class UserSessionRepository: UserSessionRepositoryProtocol {
         self.keychain = keychain
     }
 
-    func saveUser(_ user: User) -> Completable {
-        Completable.create { [weak self] observer in
-            do {
-                try self?.keychain.set(CodableUser(user: user), for: .user)
-            } catch {
-                observer(.error(error))
-            }
-            observer(.completed)
-            return Disposables.create()
-        }
-    }
-
     func getCurrentUser() -> Single<User?> {
         Single.create { [weak self] single in
             do {
@@ -36,6 +24,30 @@ final class UserSessionRepository: UserSessionRepositoryProtocol {
                 single(.failure(error))
             }
 
+            return Disposables.create()
+        }
+    }
+
+    func removeCurrentUser() -> Completable {
+        Completable.create { [weak self] observer in
+            do {
+                try self?.keychain.remove(.user)
+            } catch {
+                observer(.error(error))
+            }
+            observer(.completed)
+            return Disposables.create()
+        }
+    }
+
+    func saveUser(_ user: User) -> Completable {
+        Completable.create { [weak self] observer in
+            do {
+                try self?.keychain.set(CodableUser(user: user), for: .user)
+            } catch {
+                observer(.error(error))
+            }
+            observer(.completed)
             return Disposables.create()
         }
     }

--- a/NimbleMedium/Sources/Domain/Repositories/User/UserSessionRepositoryProtocol.swift
+++ b/NimbleMedium/Sources/Domain/Repositories/User/UserSessionRepositoryProtocol.swift
@@ -10,6 +10,7 @@ import RxSwift
 // sourcery: AutoMockable
 protocol UserSessionRepositoryProtocol: AnyObject {
 
-    func saveUser(_ user: User) -> Completable
     func getCurrentUser() -> Single<User?>
+    func removeCurrentUser() -> Completable
+    func saveUser(_ user: User) -> Completable
 }

--- a/NimbleMedium/Sources/Domain/UseCases/Auth/LogoutUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/Auth/LogoutUseCase.swift
@@ -17,9 +17,7 @@ final class LogoutUseCase: LogoutUseCaseProtocol {
 
     private let userSessionRepository: UserSessionRepositoryProtocol
 
-    init(
-        userSessionRepository: UserSessionRepositoryProtocol
-    ) {
+    init(userSessionRepository: UserSessionRepositoryProtocol) {
         self.userSessionRepository = userSessionRepository
     }
 

--- a/NimbleMedium/Sources/Domain/UseCases/Auth/LogoutUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/Auth/LogoutUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  LogoutUseCase.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 11/10/2021.
+//
+
+import RxSwift
+
+// sourcery: AutoMockable
+protocol LogoutUseCaseProtocol: AnyObject {
+
+    func execute() -> Completable
+}
+
+final class LogoutUseCase: LogoutUseCaseProtocol {
+
+    private let userSessionRepository: UserSessionRepositoryProtocol
+
+    init(
+        userSessionRepository: UserSessionRepositoryProtocol
+    ) {
+        self.userSessionRepository = userSessionRepository
+    }
+
+    func execute() -> Completable {
+        userSessionRepository
+            .removeCurrentUser()
+    }
+}

--- a/NimbleMedium/Sources/Domain/UseCases/User/GetCurrentSessionUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/User/GetCurrentSessionUseCase.swift
@@ -17,9 +17,7 @@ final class GetCurrentSessionUseCase: GetCurrentSessionUseCaseProtocol {
 
     private let userSessionRepository: UserSessionRepositoryProtocol
 
-    init(
-        userSessionRepository: UserSessionRepositoryProtocol
-    ) {
+    init(userSessionRepository: UserSessionRepositoryProtocol) {
         self.userSessionRepository = userSessionRepository
     }
 

--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -75,6 +75,9 @@ extension Resolver: ResolverRegistering {
             )
         }.implements(LoginUseCaseProtocol.self)
         register {
+            LogoutUseCase(userSessionRepository: resolve())
+        }.implements(LogoutUseCaseProtocol.self)
+        register {
             SignupUseCase(
                 authRepository: resolve(),
                 userSessionRepository: resolve()

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
@@ -76,7 +76,7 @@ struct LoginView: View {
                 AuthSecureFieldView(
                     placeholder: Localizable.loginTextFieldPasswordPlaceholder(),
                     text: $password)
-                AppMainButton(title: Localizable.actionLogin()) {
+                AppMainButton(title: Localizable.actionLoginText()) {
                     hideKeyboard()
                     viewModel.input.didTapLoginButton(email: email, password: password)
                 }

--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginViewModel.swift
@@ -9,12 +9,14 @@ import RxSwift
 import RxCocoa
 import Resolver
 
+// sourcery: AutoMockable
 protocol LoginViewModelInput {
 
     func didTapLoginButton(email: String, password: String)
     func didTapNoAccountButton()
 }
 
+// sourcery: AutoMockable
 protocol LoginViewModelOutput {
 
     var didLogin: Signal<Void> { get }
@@ -23,6 +25,7 @@ protocol LoginViewModelOutput {
     var isLoading: Driver<Bool> { get }
 }
 
+// sourcery: AutoMockable
 protocol LoginViewModelProtocol: ObservableViewModel {
 
     var input: LoginViewModelInput { get }

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsView.swift
@@ -21,6 +21,7 @@ struct SideMenuActionsView: View {
     @State private var isShowingLoginScreen = false
     @State private var isShowingSignupScreen = false
     @State private var isShowingMyProfileScreen = false
+    @State private var showLogoutConfirmationAlert = false
 
     var body: some View {
         if isAuthenticated {
@@ -49,7 +50,16 @@ struct SideMenuActionsView: View {
                 text: Localizable.menuOptionLogout(),
                 iconName: R.image.iconLogout.name
             ) {
-                // TODO: Implement this option tap action in the integrate task
+                showLogoutConfirmationAlert.toggle()
+            }
+            .alert(isPresented: $showLogoutConfirmationAlert) {
+                Alert(
+                    title: Text(Localizable.popupConfirmLogoutTitle()),
+                    primaryButton: .destructive(
+                        Text(Localizable.actionConfirmText()), action: { viewModel.input.selectLogoutOption() }
+                    ),
+                    secondaryButton: .default(Text(Localizable.actionCancelText()))
+                )
             }
         }
         .bind(viewModel.output.didSelectMyProfileOption, to: _isShowingMyProfileScreen)

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
@@ -18,12 +18,14 @@ protocol SideMenuActionsViewModelInput {
         homeViewModel: HomeViewModelProtocol
     )
     func selectLoginOption()
+    func selectLogoutOption()
     func selectMyProfileOption()
     func selectSignupOption()
 }
 
 protocol SideMenuActionsViewModelOutput {
 
+    var didLogout: Signal<Void> { get }
     var didSelectLoginOption: Signal<Bool> { get }
     var didSelectMyProfileOption: Signal<Bool> { get }
     var didSelectSignupOption: Signal<Bool> { get }
@@ -43,6 +45,7 @@ final class SideMenuActionsViewModel: ObservableObject, SideMenuActionsViewModel
     var input: SideMenuActionsViewModelInput { self }
     var output: SideMenuActionsViewModelOutput { self }
 
+    @PublishRelayProperty var didLogout: Signal<Void>
     @PublishRelayProperty var didSelectLoginOption: Signal<Bool>
     @PublishRelayProperty var didSelectMyProfileOption: Signal<Bool>
     @PublishRelayProperty var didSelectSignupOption: Signal<Bool>
@@ -50,13 +53,21 @@ final class SideMenuActionsViewModel: ObservableObject, SideMenuActionsViewModel
     @BehaviorRelayProperty(false) var isAuthenticated: Driver<Bool>
 
     @Injected var getCurrentSessionUseCase: GetCurrentSessionUseCaseProtocol
+    @Injected var logoutUseCase: LogoutUseCaseProtocol
 
     private let getCurrentUserSessionTrigger = PublishRelay<Void>()
+    private let logoutTrigger = PublishRelay<Void>()
 
     init() {
         getCurrentUserSessionTrigger
             .withUnretained(self)
             .flatMapLatest { owner, _ in owner.getCurrentUserSessionTriggered(owner: owner) }
+            .subscribe()
+            .disposed(by: disposeBag)
+
+        logoutTrigger
+            .withUnretained(self)
+            .flatMapLatest { owner, _ in owner.logoutTriggered(owner: owner) }
             .subscribe()
             .disposed(by: disposeBag)
     }
@@ -89,6 +100,10 @@ extension SideMenuActionsViewModel: SideMenuActionsViewModelInput {
             .disposed(by: disposeBag)
     }
 
+    func selectLogoutOption() {
+        logoutTrigger.accept(())
+    }
+
     func selectLoginOption() {
         $didSelectLoginOption.accept(true)
     }
@@ -113,6 +128,18 @@ private extension SideMenuActionsViewModel {
             .do(
                 onSuccess: { owner.$isAuthenticated.accept($0) },
                 onError: { _ in owner.$isAuthenticated.accept(false) }
+            )
+            .asObservable()
+            .mapToVoid()
+            .catchAndReturn(())
+    }
+
+    func logoutTriggered(owner: SideMenuActionsViewModel) -> Observable<Void> {
+        logoutUseCase
+            .execute()
+            .do(
+                onError: { error in print("Logout failed with error: \(error.detail)") },
+                onCompleted: { owner.$didLogout.accept(()) }
             )
             .asObservable()
             .mapToVoid()

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
@@ -10,6 +10,7 @@ import RxCocoa
 import Combine
 import Resolver
 
+// sourcery: AutoMockable
 protocol SideMenuActionsViewModelInput {
 
     func bindData(

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuMain/SideMenuViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuMain/SideMenuViewModel.swift
@@ -39,6 +39,13 @@ final class SideMenuViewModel: ObservableObject, SideMenuViewModelProtocol {
 extension SideMenuViewModel: SideMenuViewModelInput {
 
     func bindData(sideMenuActionsViewModel: SideMenuActionsViewModelProtocol) {
+        sideMenuActionsViewModel.output.didLogout.asObservable()
+            .withUnretained(self)
+            .bind { _ in
+                self.$didSelectMenuOption.accept(())
+            }
+            .disposed(by: disposeBag)
+        
         sideMenuActionsViewModel.output.didSelectLoginOption.asObservable()
             .withUnretained(self)
             .bind { _ in

--- a/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
@@ -81,7 +81,7 @@ struct SignupView: View {
                 AuthSecureFieldView(
                     placeholder: Localizable.signupTextFieldPasswordPlaceholder(),
                     text: $password)
-                AppMainButton(title: Localizable.actionSignup()) {
+                AppMainButton(title: Localizable.actionSignupText()) {
                     hideKeyboard()
                     viewModel.input.didTapSignupButton(username: username, email: email, password: password)
                 }

--- a/NimbleMedium/Sources/Presentation/Modules/Signup/SignupViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Signup/SignupViewModel.swift
@@ -15,6 +15,7 @@ protocol SignupViewModelInput {
     func didTapHaveAccountButton()
 }
 
+// sourcery: AutoMockable
 protocol SignupViewModelOutput {
 
     var didSelectHaveAccount: Signal<Void> { get }
@@ -23,6 +24,7 @@ protocol SignupViewModelOutput {
     var isLoading: Driver<Bool> { get }
 }
 
+// sourcery: AutoMockable
 protocol SignupViewModelProtocol: ObservableViewModel {
 
     var input: SignupViewModelInput { get }

--- a/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
+++ b/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
@@ -42,6 +42,7 @@ extension Resolver {
         Resolver.mock.register { GetListArticlesUseCaseProtocolMock() }.implements(GetListArticlesUseCaseProtocol.self)
         Resolver.mock.register { GetUserProfileUseCaseProtocolMock() }.implements(GetUserProfileUseCaseProtocol.self)
         Resolver.mock.register { LoginUseCaseProtocolMock() }.implements(LoginUseCaseProtocol.self)
+        Resolver.mock.register { LogoutUseCaseProtocolMock() }.implements(LogoutUseCaseProtocol.self)
         Resolver.mock.register { GetCreatedArticlesUseCaseProtocolMock() }
             .implements(GetCreatedArticlesUseCaseProtocol.self)
         Resolver.mock.register { GetFavouritedArticlesUseCaseProtocolMock() }
@@ -51,5 +52,7 @@ extension Resolver {
     private static func registerViewModels() {
         Resolver.mock.register { ArticleRowViewModelProtocolMock() }.implements(ArticleRowViewModelProtocol.self)
         Resolver.mock.register { HomeViewModelProtocolMock() }.implements(HomeViewModelProtocol.self)
+        Resolver.mock.register { LoginViewModelProtocolMock() }.implements(LoginViewModelProtocol.self)
+        Resolver.mock.register { SignupViewModelProtocolMock() }.implements(SignupViewModelProtocol.self)
     }
 }

--- a/NimbleMediumTests/Sources/Specs/Domain/UseCases/Auth/LogoutUseCaseSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Domain/UseCases/Auth/LogoutUseCaseSpec.swift
@@ -1,0 +1,80 @@
+//
+//  LogoutUseCaseSpec.swift
+//  NimbleMediumTests
+//
+//  Created by Minh Pham on 11/10/2021.
+//
+
+import Quick
+import Nimble
+import RxNimble
+import RxSwift
+import RxTest
+
+@testable import NimbleMedium
+
+final class LogoutUseCaseSpec: QuickSpec {
+    
+    override func spec() {
+        var usecase: LogoutUseCase!
+        var userSessionRepository: UserSessionRepositoryProtocolMock!
+        var scheduler: TestScheduler!
+        var disposeBag: DisposeBag!
+        
+        describe("an LogoutUseCase") {
+            
+            beforeEach {
+                disposeBag = DisposeBag()
+                userSessionRepository = UserSessionRepositoryProtocolMock()
+                usecase = LogoutUseCase(userSessionRepository: userSessionRepository)
+                scheduler = TestScheduler(initialClock: 0)
+            }
+            
+            describe("its execute() call") {
+                
+                context("when UserSessionRepository.removeCurrentUser() returns success") {
+                    
+                    var outputCompleted: TestableObserver<Bool>!
+                    
+                    beforeEach {
+                        outputCompleted = scheduler.createObserver(Bool.self)
+                        userSessionRepository.removeCurrentUserReturnValue = .empty()
+                        
+                        usecase.execute()
+                            .asObservable()
+                            .materialize()
+                            .map { $0.isCompleted }
+                            .bind(to: outputCompleted )
+                            .disposed(by: disposeBag)
+                    }
+                    
+                    it("returns completed logout event") {
+                        expect(outputCompleted.events.first?.value.element) == true
+                    }
+                }
+                
+                context("when UserSessionRepository.removeCurrentUser() returns failure") {
+                    
+                    var outputError: TestableObserver<Error?>!
+                    
+                    beforeEach {
+                        outputError = scheduler.createObserver(Optional<Error>.self)
+                        userSessionRepository.removeCurrentUserReturnValue = .error(TestError.mock)
+                        
+                        usecase.execute()
+                            .asObservable()
+                            .materialize()
+                            .map { $0.error }
+                            .bind(to: outputError)
+                            .disposed(by: disposeBag)
+                    }
+                    
+                    it("returns the corresponding error") {
+                        let error = outputError.events.first?.value.element as? TestError
+                        expect(error) == TestError.mock
+                    }
+                }
+            }
+        }
+    }
+}

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModelSpec.swift
@@ -1,0 +1,234 @@
+//
+//  SideMenuActionsViewModelSpec.swift
+//  NimbleMediumTests
+//
+//  Created by Minh Pham on 11/10/2021.
+//
+
+import Quick
+import Nimble
+import RxNimble
+import RxSwift
+import RxTest
+import Resolver
+
+@testable import NimbleMedium
+
+final class SideMenuActionsViewModelSpec: QuickSpec {
+
+    @LazyInjected var homeViewModel: HomeViewModelProtocolMock
+    @LazyInjected var loginViewModel: LoginViewModelProtocolMock
+    @LazyInjected var signupViewModel: SignupViewModelProtocolMock
+    
+    @LazyInjected var logoutUseCase: LogoutUseCaseProtocolMock
+    @LazyInjected var getCurrentSessionUseCase: GetCurrentSessionUseCaseProtocolMock
+
+    override func spec() {
+
+        var viewModel: SideMenuActionsViewModel!
+        var scheduler: TestScheduler!
+        var disposeBag: DisposeBag!
+
+        var homeViewModelOutput: HomeViewModelOutputMock!
+        var loginViewModelOutput: LoginViewModelOutputMock!
+        var signupViewModelOutput: SignupViewModelOutputMock!
+
+        describe("a SideMenuActionsViewModel") {
+
+            beforeEach {
+                Resolver.registerMockServices()
+                scheduler = TestScheduler(initialClock: 0)
+                disposeBag = DisposeBag()
+                viewModel = SideMenuActionsViewModel()
+
+                homeViewModelOutput = HomeViewModelOutputMock()
+                homeViewModelOutput.underlyingIsSideMenuOpenDidChange = .just(false)
+                self.homeViewModel.output = homeViewModelOutput
+
+                loginViewModelOutput = LoginViewModelOutputMock()
+                loginViewModelOutput.underlyingDidSelectNoAccount = .just(())
+                self.loginViewModel.output = loginViewModelOutput
+
+                signupViewModelOutput = SignupViewModelOutputMock()
+                signupViewModelOutput.underlyingDidSelectHaveAccount = .just(())
+                self.signupViewModel.output = signupViewModelOutput
+            }
+
+            describe("its bindData call") {
+
+                context("when homeViewModel isSideMenuOpenDidChange emits event") {
+
+                    beforeEach {
+                        homeViewModelOutput.underlyingIsSideMenuOpenDidChange = .just(true)
+                    }
+
+                    context("when getCurrentSessionUseCase returns a valid user session") {
+
+                        let user = UserDummy()
+
+                        beforeEach {
+                            self.getCurrentSessionUseCase.getCurrentUserSessionReturnValue =
+                                .just(user, on: scheduler, at: 50)
+                            bindData()
+                        }
+
+                        it("returns output with isAuthenticated as true") {
+                            expect(viewModel.output.isAuthenticated)
+                                .events(scheduler: scheduler, disposeBag: disposeBag)
+                                .to(equal([
+                                    .next(0, false),
+                                    .next(50, true)
+                                ]))
+                        }
+                    }
+
+                    context("when getCurrentSessionUseCase returns an invalid user session") {
+
+                        beforeEach {
+                            self.getCurrentSessionUseCase.getCurrentUserSessionReturnValue =
+                                .just(nil, on: scheduler, at: 50)
+                            bindData()
+                        }
+
+                        it("returns output with isAuthenticated as false") {
+                            expect(viewModel.output.isAuthenticated)
+                                .events(scheduler: scheduler, disposeBag: disposeBag)
+                                .to(equal([
+                                    .next(0, false),
+                                    .next(50, false)
+                                ]))
+                        }
+                    }
+
+                    context("when getCurrentSessionUseCase returns an error getting the user session") {
+
+                        beforeEach {
+                            self.getCurrentSessionUseCase.getCurrentUserSessionReturnValue =
+                                .error(TestError.mock, on: scheduler, at: 50)
+                            bindData()
+                        }
+
+                        it("returns output with isAuthenticated as false") {
+                            expect(viewModel.output.isAuthenticated)
+                                .events(scheduler: scheduler, disposeBag: disposeBag)
+                                .to(equal([
+                                    .next(0, false),
+                                    .next(50, false)
+                                ]))
+                        }
+                    }
+                }
+
+                context("when loginViewModel didSelectNoAccount emits event") {
+
+                    it("returns output with didSelectSignupOption as true") {
+                        scheduler.scheduleAt(5) {
+                            bindData()
+                        }
+
+                        expect(viewModel.output.didSelectSignupOption)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .to(equal([.next(5, true)]))
+                    }
+                }
+
+                context("when signupViewModel didSelectHaveAccount emits event") {
+
+                    it("returns output with didSelectLoginOption as true") {
+                        scheduler.scheduleAt(5) {
+                            bindData()
+                        }
+
+                        expect(viewModel.output.didSelectLoginOption)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .to(equal([.next(5, true)]))
+                    }
+                }
+            }
+
+            describe("its selectLogoutOption call") {
+
+                context("when logoutUseCase returns success") {
+
+                    beforeEach {
+                        self.logoutUseCase.executeReturnValue = .empty()
+                    }
+
+                    it("returns output with didLogout event") {
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.selectLogoutOption()
+                        }
+
+                        expect(viewModel.output.didLogout)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .notTo(beEmpty())
+                    }
+                }
+
+                context("when logoutUseCase returns failure") {
+
+                    beforeEach {
+                        self.logoutUseCase.executeReturnValue = .error(TestError.mock)
+                    }
+
+                    it("returns output without didLogout event") {
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.selectLogoutOption()
+                        }
+
+                        expect(viewModel.output.didLogout)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .to(beEmpty())
+                    }
+                }
+            }
+
+            context("when selectLoginOption is called") {
+
+                it("returns output with didSelectLoginOption as true") {
+                    scheduler.scheduleAt(5) {
+                        viewModel.input.selectLoginOption()
+                    }
+
+                    expect(viewModel.output.didSelectLoginOption)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(5, true)]))
+                }
+            }
+
+            context("when selectMyProfileOption is called") {
+
+                it("returns output with didSelectMyProfileOption as true") {
+                    scheduler.scheduleAt(5) {
+                        viewModel.input.selectMyProfileOption()
+                    }
+
+                    expect(viewModel.output.didSelectMyProfileOption)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(5, true)]))
+                }
+            }
+
+            context("when selectSignupOption is called") {
+
+                it("returns output with didSelectSignupOption as true") {
+                    scheduler.scheduleAt(5) {
+                        viewModel.input.selectSignupOption()
+                    }
+
+                    expect(viewModel.output.didSelectSignupOption)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(5, true)]))
+                }
+            }
+        }
+
+        func bindData() {
+            viewModel.input.bindData(
+                loginViewModel: self.loginViewModel,
+                signupViewModel: self.signupViewModel,
+                homeViewModel: self.homeViewModel
+            )
+        }
+    }
+}

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/SideMenu/SideMenuHeader/SideMenuHeaderViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/SideMenu/SideMenuHeader/SideMenuHeaderViewModelSpec.swift
@@ -33,7 +33,7 @@ final class SideMenuHeaderViewModelSpec: QuickSpec {
                 disposeBag = DisposeBag()
             }
 
-            describe("its sideMenuDidOpen call") {
+            describe("its homeViewModel isSideMenuOpenDidChange call") {
 
                 beforeEach {
                     let homeViewModelOutput = HomeViewModelOutputMock()


### PR DESCRIPTION
Resolved #42

## What happened

When the users logged in the application successfully, they will be able to logout the application with a `Logout` option in the left menu from `Home` Screen.

## Insight

- [x] the `Logout` option is only shown when there is an authenticated user.
- [x] When the users tap on the `Logout` option in the left menu, hide the left menu and show a native confirm popup to confirm the logout.
- [x] The popup message text is: `Are you sure you want to logout?` with 2 buttons: `Confirm` in destructive style and `Cancel` in cancel style.
- [x] When the users select `Confirm` option on the popup, clear all user data and access token from the current session.
- [x] Toggle to hide the left menu.
- [ ] ~Show the `Home` screen in unauthenticated state (no more `Your Feed` option, no `Favorite Article` option, no `Create Article` option, the left menu shows the default header with 2 options: `Login` and `Sign up`).~ -> the above options are not available at the moment, will update when they are available.
- [x] Add unit tests for the following files: `LogoutUseCase.swift` and `SideMenuActionsViewModel.swift`.

## Proof Of Work

https://user-images.githubusercontent.com/70877098/136774599-b2a2154e-177c-474f-8797-244b347aa781.mov


- LogoutUseCase:

![Screen Shot 2021-10-11 at 17 17 31](https://user-images.githubusercontent.com/70877098/136774630-6375fc78-0b50-4b69-8e6c-94a72ae98f18.png)
 
- SideMenuActionsViewModel:

![Screen Shot 2021-10-11 at 17 28 19](https://user-images.githubusercontent.com/70877098/136775544-485f771a-d8da-4953-9a62-73699af68bcd.png)


