### PR TITLE
[#61] As a user, I can update my own profile details

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		24204C9E26D5289900534314 /* Background.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24204C9D26D5289900534314 /* Background.swift */; };
 		24204CA026D625D300534314 /* SideMenuActionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24204C9F26D625D300534314 /* SideMenuActionsViewModel.swift */; };
 		24204CA226D62B6900534314 /* SideMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24204CA126D62B6900534314 /* SideMenuViewModel.swift */; };
+		2422A8752716985E0048DBDC /* EditProfileViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2422A8742716985E0048DBDC /* EditProfileViewModelSpec.swift */; };
 		2424B22C26D4A22B00CF07B5 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2424B22B26D4A22B00CF07B5 /* LoginView.swift */; };
 		2424B22F26D4A2EF00CF07B5 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2424B22E26D4A2EF00CF07B5 /* LoginViewModel.swift */; };
 		243508732715676B00A2AE46 /* UpdateCurrentUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243508722715676B00A2AE46 /* UpdateCurrentUserUseCase.swift */; };
@@ -238,6 +239,7 @@
 		24204C9D26D5289900534314 /* Background.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Background.swift; sourceTree = "<group>"; };
 		24204C9F26D625D300534314 /* SideMenuActionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionsViewModel.swift; sourceTree = "<group>"; };
 		24204CA126D62B6900534314 /* SideMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuViewModel.swift; sourceTree = "<group>"; };
+		2422A8742716985E0048DBDC /* EditProfileViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileViewModelSpec.swift; sourceTree = "<group>"; };
 		2424B22B26D4A22B00CF07B5 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		2424B22E26D4A2EF00CF07B5 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		243508722715676B00A2AE46 /* UpdateCurrentUserUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCurrentUserUseCase.swift; sourceTree = "<group>"; };
@@ -503,6 +505,14 @@
 				2435087A2715768E00A2AE46 /* UpdateCurrentUserUseCaseSpec.swift */,
 			);
 			path = Auth;
+			sourceTree = "<group>";
+		};
+		241D3531271695B2007F6BA9 /* EditProfile */ = {
+			isa = PBXGroup;
+			children = (
+				2422A8742716985E0048DBDC /* EditProfileViewModelSpec.swift */,
+			);
+			path = EditProfile;
 			sourceTree = "<group>";
 		};
 		24204CA326D6465C00534314 /* SideMenuActions */ = {
@@ -1246,6 +1256,7 @@
 			children = (
 				2D29A70B26F44415001EA24F /* ArticleComments */,
 				2DB31D4F26F1960B007254B9 /* ArticleDetail */,
+				241D3531271695B2007F6BA9 /* EditProfile */,
 				2D79A8FA26EF4A70007B81D1 /* Feeds */,
 				24F3D7BC26DE041F00DE2420 /* Login */,
 				247CD0ED271429DB002D90D1 /* SideMenu */,
@@ -2244,6 +2255,7 @@
 				2DEFAB2027153998007C2378 /* AuthenticatedNetworkAPIProtocolMock.swift in Sources */,
 				2435087E27157E2F00A2AE46 /* GetCurrentUserUseCaseSpec.swift in Sources */,
 				2D892BAB26E89E4500579856 /* GetListArticlesUseCaseSpec.swift in Sources */,
+				2422A8752716985E0048DBDC /* EditProfileViewModelSpec.swift in Sources */,
 				2D882EE226F1CE8F00DB6560 /* APIArticleCommentsResponse+Dummy.swift in Sources */,
 				2D87822F26EB3B3A0080FEF6 /* R.generated.swift in Sources */,
 				24B277D62701C31100332FEA /* GetUserProfileUseCaseSpec.swift in Sources */,

--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		24204CA026D625D300534314 /* SideMenuActionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24204C9F26D625D300534314 /* SideMenuActionsViewModel.swift */; };
 		24204CA226D62B6900534314 /* SideMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24204CA126D62B6900534314 /* SideMenuViewModel.swift */; };
 		2422A8752716985E0048DBDC /* EditProfileViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2422A8742716985E0048DBDC /* EditProfileViewModelSpec.swift */; };
+		2422A87927169E980048DBDC /* SideMenuViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2422A87827169E980048DBDC /* SideMenuViewModelSpec.swift */; };
 		2424B22C26D4A22B00CF07B5 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2424B22B26D4A22B00CF07B5 /* LoginView.swift */; };
 		2424B22F26D4A2EF00CF07B5 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2424B22E26D4A2EF00CF07B5 /* LoginViewModel.swift */; };
 		243508732715676B00A2AE46 /* UpdateCurrentUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243508722715676B00A2AE46 /* UpdateCurrentUserUseCase.swift */; };
@@ -240,6 +241,7 @@
 		24204C9F26D625D300534314 /* SideMenuActionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionsViewModel.swift; sourceTree = "<group>"; };
 		24204CA126D62B6900534314 /* SideMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuViewModel.swift; sourceTree = "<group>"; };
 		2422A8742716985E0048DBDC /* EditProfileViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileViewModelSpec.swift; sourceTree = "<group>"; };
+		2422A87827169E980048DBDC /* SideMenuViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuViewModelSpec.swift; sourceTree = "<group>"; };
 		2424B22B26D4A22B00CF07B5 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		2424B22E26D4A2EF00CF07B5 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		243508722715676B00A2AE46 /* UpdateCurrentUserUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCurrentUserUseCase.swift; sourceTree = "<group>"; };
@@ -545,6 +547,14 @@
 			path = SideMenuHeader;
 			sourceTree = "<group>";
 		};
+		2422A87727169E840048DBDC /* SideMenuMain */ = {
+			isa = PBXGroup;
+			children = (
+				2422A87827169E980048DBDC /* SideMenuViewModelSpec.swift */,
+			);
+			path = SideMenuMain;
+			sourceTree = "<group>";
+		};
 		2424B22D26D4A23100CF07B5 /* Login */ = {
 			isa = PBXGroup;
 			children = (
@@ -649,6 +659,7 @@
 			children = (
 				247CD0EE271429F4002D90D1 /* SideMenuActions */,
 				246B387726F8A7BD003173FD /* SideMenuHeader */,
+				2422A87727169E840048DBDC /* SideMenuMain */,
 			);
 			path = SideMenu;
 			sourceTree = "<group>";
@@ -2257,6 +2268,7 @@
 				2D892BAB26E89E4500579856 /* GetListArticlesUseCaseSpec.swift in Sources */,
 				2422A8752716985E0048DBDC /* EditProfileViewModelSpec.swift in Sources */,
 				2D882EE226F1CE8F00DB6560 /* APIArticleCommentsResponse+Dummy.swift in Sources */,
+				2422A87927169E980048DBDC /* SideMenuViewModelSpec.swift in Sources */,
 				2D87822F26EB3B3A0080FEF6 /* R.generated.swift in Sources */,
 				24B277D62701C31100332FEA /* GetUserProfileUseCaseSpec.swift in Sources */,
 				248E13B426F07F5800439BCC /* Resolver+Tests.swift in Sources */,

--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		241B4EEA26D3B3F4000409CC /* SideMenuActionItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */; };
 		241B99DC26DF23030041207F /* AutoMockable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B99DB26DF23030041207F /* AutoMockable.generated.swift */; };
 		241B99DE26DF34720041207F /* SignupUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B99DD26DF34720041207F /* SignupUseCase.swift */; };
+		241D352C27167C9B007F6BA9 /* EditProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241D352B27167C9B007F6BA9 /* EditProfileViewModel.swift */; };
+		241D352E271682B4007F6BA9 /* String+EmptyCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241D352D271682B4007F6BA9 /* String+EmptyCheck.swift */; };
+		241D353027168609007F6BA9 /* EditProfileView+UIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241D352F27168609007F6BA9 /* EditProfileView+UIModel.swift */; };
 		241F5B852701A9F8002E13FC /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241F5B842701A9F7002E13FC /* UserRepository.swift */; };
 		241F5B872701AADD002E13FC /* UserRequestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241F5B862701AADD002E13FC /* UserRequestConfiguration.swift */; };
 		241F5B892701ABEC002E13FC /* APIProfileResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241F5B882701ABEC002E13FC /* APIProfileResponse.swift */; };
@@ -225,6 +228,9 @@
 		241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionItemView.swift; sourceTree = "<group>"; };
 		241B99DB26DF23030041207F /* AutoMockable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoMockable.generated.swift; sourceTree = "<group>"; };
 		241B99DD26DF34720041207F /* SignupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupUseCase.swift; sourceTree = "<group>"; };
+		241D352B27167C9B007F6BA9 /* EditProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileViewModel.swift; sourceTree = "<group>"; };
+		241D352D271682B4007F6BA9 /* String+EmptyCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+EmptyCheck.swift"; sourceTree = "<group>"; };
+		241D352F27168609007F6BA9 /* EditProfileView+UIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditProfileView+UIModel.swift"; sourceTree = "<group>"; };
 		241F5B842701A9F7002E13FC /* UserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
 		241F5B862701AADD002E13FC /* UserRequestConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRequestConfiguration.swift; sourceTree = "<group>"; };
 		241F5B882701ABEC002E13FC /* APIProfileResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProfileResponse.swift; sourceTree = "<group>"; };
@@ -550,6 +556,8 @@
 			isa = PBXGroup;
 			children = (
 				244E0FF427152DA000C01139 /* EditProfileView.swift */,
+				241D352B27167C9B007F6BA9 /* EditProfileViewModel.swift */,
+				241D352F27168609007F6BA9 /* EditProfileView+UIModel.swift */,
 			);
 			path = EditProfile;
 			sourceTree = "<group>";
@@ -882,9 +890,10 @@
 		2D303B3C26C28AE900EEF1C0 /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
-				2459B31026D74B3100ABCE61 /* JSONDecoder+Default.swift */,
 				2D79A8F726EEFC24007B81D1 /* Date+Format.swift */,
 				2D1D727326EB305F00431679 /* DateFormatter+Formats.swift */,
+				2459B31026D74B3100ABCE61 /* JSONDecoder+Default.swift */,
+				241D352D271682B4007F6BA9 /* String+EmptyCheck.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -2168,6 +2177,7 @@
 				24B277D32701C1EB00332FEA /* GetUserProfileUseCase.swift in Sources */,
 				241A5A252713FA9B00BC33F1 /* LogoutUseCase.swift in Sources */,
 				248E13A926F054AD00439BCC /* Resolver+Injection.swift in Sources */,
+				241D353027168609007F6BA9 /* EditProfileView+UIModel.swift in Sources */,
 				2DEF1F9A26E6092500EB93CC /* APIArticlesResponse.swift in Sources */,
 				241F5B8B2701BEFB002E13FC /* UserRepositoryProtocol.swift in Sources */,
 				2D55E4A926DF235000161052 /* Profile.swift in Sources */,
@@ -2179,12 +2189,14 @@
 				24F3D7AA26DCE54C00DE2420 /* CodableUser.swift in Sources */,
 				2D5485BE26CA0D2C00FFE707 /* PublishRelayProperty.swift in Sources */,
 				2459B31C26D74F4700ABCE61 /* AuthRequestConfiguration.swift in Sources */,
+				241D352E271682B4007F6BA9 /* String+EmptyCheck.swift in Sources */,
 				2D17E4F226F07996001D3F90 /* NavigationBarPrimaryStyle.swift in Sources */,
 				244E0FF527152DA000C01139 /* EditProfileView.swift in Sources */,
 				2D979C30270302650084A3F8 /* GetCreatedArticlesUseCase.swift in Sources */,
 				2DEF1F9426E6029200EB93CC /* DecodableArticle.swift in Sources */,
 				2DB31D4E26F18EAB007254B9 /* ArticleDetailViewModel.swift in Sources */,
 				2D17E4F426F07ABA001D3F90 /* View+If.swift in Sources */,
+				241D352C27167C9B007F6BA9 /* EditProfileViewModel.swift in Sources */,
 				241B4EEA26D3B3F4000409CC /* SideMenuActionItemView.swift in Sources */,
 				2DEFAB2227153CF4007C2378 /* FollowUserUseCase.swift in Sources */,
 				2D084734270D793300DFFF69 /* UserProfileCreatedArticlesTab.swift in Sources */,

--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -125,6 +125,7 @@ extension Resolver: ResolverRegistering {
         register { _, args in
             ArticleRowViewModel(article: args.get())
         }.implements(ArticleRowViewModelProtocol.self)
+        register { EditProfileViewModel() }.implements(EditProfileViewModelProtocol.self)
         register { FeedsViewModel() }.implements(FeedsViewModelProtocol.self).scope(.cached)
         register { HomeViewModel() }.implements(HomeViewModelProtocol.self).scope(.cached)
         register { LoginViewModel() }.implements(LoginViewModelProtocol.self).scope(.cached)

--- a/NimbleMedium/Sources/Presentation/Modules/EditProfile/EditProfileView+UIModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditProfile/EditProfileView+UIModel.swift
@@ -1,0 +1,33 @@
+//
+//  EditProfileView+UIModel.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 13/10/2021.
+//
+
+import Foundation
+
+extension EditProfileView {
+
+     struct UIModel: Equatable {
+
+         var username: String
+         var email: String
+         var avatarURL: String
+         var bio: String
+
+         init(username: String = "", email: String = "", avatarURL: String = "", bio: String = "") {
+             self.username = username
+             self.email = email
+             self.avatarURL = avatarURL
+             self.bio = bio
+         }
+
+         var allFieldsAreEmpty: Bool {
+             username.isEmpty &&
+             email.isEmpty &&
+             avatarURL.isEmpty &&
+             bio.isEmpty
+         }
+     }
+ }

--- a/NimbleMedium/Sources/Presentation/Modules/EditProfile/EditProfileView+UIModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditProfile/EditProfileView+UIModel.swift
@@ -11,23 +11,16 @@ extension EditProfileView {
 
      struct UIModel: Equatable {
 
-         var username: String
-         var email: String
-         var avatarURL: String
-         var bio: String
+         let username: String
+         let email: String
+         let avatarURL: String
+         let bio: String
 
          init(username: String = "", email: String = "", avatarURL: String = "", bio: String = "") {
              self.username = username
              self.email = email
              self.avatarURL = avatarURL
              self.bio = bio
-         }
-
-         var allFieldsAreEmpty: Bool {
-             username.isEmpty &&
-             email.isEmpty &&
-             avatarURL.isEmpty &&
-             bio.isEmpty
          }
      }
  }

--- a/NimbleMedium/Sources/Presentation/Modules/EditProfile/EditProfileView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditProfile/EditProfileView.swift
@@ -5,19 +5,22 @@
 //  Created by Minh Pham on 12/10/2021.
 //
 
+import Resolver
 import SwiftUI
 import ToastUI
-import Resolver
 
 struct EditProfileView: View {
 
+    @ObservedViewModel private var viewModel: EditProfileViewModelProtocol = Resolver.resolve()
+
     @Environment(\.presentationMode) var presentationMode
 
-    @State private var avatarURL = ""
-    @State private var username = ""
-    @State private var bio = ""
-    @State private var email = ""
+    @State private var uiModel = UIModel()
     @State private var password = ""
+
+    @State private var errorMessage = ""
+    @State private var errorToast = false
+    @State private var loadingToast = false
 
     var body: some View {
         NavigationView {
@@ -26,8 +29,26 @@ struct EditProfileView: View {
                 .navigationBarTitle(Localizable.editProfileTitleText(), displayMode: .inline)
                 .navigationBarColor(backgroundColor: .green)
                 .toolbar { navigationBarLeadingContent }
+                .toast(isPresented: $errorToast, dismissAfter: 3.0) {
+                    ToastView(errorMessage) { } background: {
+                        Color.clear
+                    }
+                }
+                .toast(isPresented: $loadingToast) {
+                    ToastView(String.empty) { }
+                        .toastViewStyle(IndefiniteProgressToastViewStyle())
+                }
         }
         .accentColor(.white)
+        .onAppear { viewModel.input.getCurrentUserProfile() }
+        .bind(viewModel.output.isLoading, to: _loadingToast)
+        .bind(viewModel.output.editProfileUIModel, to: _uiModel)
+        .onReceive(viewModel.output.didUpdateProfile) { _ in presentationMode.wrappedValue.dismiss() }
+        .onReceive(viewModel.output.errorMessage) { _ in
+            errorMessage = Localizable.errorGeneric()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { errorToast.toggle() }
+        }
+
     }
 
     var navigationBarLeadingContent: some ToolbarContent {
@@ -39,29 +60,37 @@ struct EditProfileView: View {
         }
     }
 
+    // swiftlint:disable closure_body_length
     var contentView: some View {
         ScrollView {
             VStack(spacing: 15.0) {
                 AppTextField(
                     placeholder: Localizable.editProfileTextFieldAvatarURLPlaceholder(),
-                    text: $avatarURL)
+                    text: $uiModel.avatarURL)
                 AppTextField(
                     placeholder: Localizable.editProfileTextFieldUsernamePlaceholder(),
-                    text: $username)
+                    text: $uiModel.username)
                 AppTextView(
                     placeholder: Localizable.editProfileTextViewBioPlaceholder(),
-                    text: $bio)
+                    text: $uiModel.bio)
                     .frame(height: 200.0, alignment: .leading)
                 AppTextField(
                     placeholder: Localizable.editProfileTextFieldEmailPlaceholder(),
-                    text: $email)
+                    text: $uiModel.email)
                 AppSecureField(
                     placeholder: Localizable.editProfileTextFieldPasswordPlaceholder(),
                     text: $password)
                 AppMainButton(title: Localizable.actionUpdateText()) {
-                    // TODO: Handle update my profile profile details in integrate task, dismiss view for now
-                    presentationMode.wrappedValue.dismiss()
+                    hideKeyboard()
+                    viewModel.input.didTapUpdateButton(
+                        username: uiModel.username,
+                        email: uiModel.email,
+                        password: password,
+                        avatarURL: uiModel.avatarURL,
+                        bio: uiModel.bio
+                    )
                 }
+                .disabled(uiModel.allFieldsAreEmpty && password.isEmpty)
             }
             .padding()
         }

--- a/NimbleMedium/Sources/Presentation/Modules/EditProfile/EditProfileViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditProfile/EditProfileViewModel.swift
@@ -14,7 +14,11 @@ import Resolver
 protocol EditProfileViewModelInput {
 
     func didTapUpdateButton(
-        username: String, email: String, password: String, avatarURL: String, bio: String
+        username: String,
+        email: String,
+        password: String,
+        avatarURL: String,
+        bio: String
     )
     func getCurrentUserProfile()
 }
@@ -78,7 +82,11 @@ extension EditProfileViewModel: EditProfileViewModelInput {
     }
 
     func didTapUpdateButton(
-        username: String, email: String, password: String, avatarURL: String, bio: String
+        username: String,
+        email: String,
+        password: String,
+        avatarURL: String,
+        bio: String
     ) {
         $isLoading.accept(true)
         updateCurrentUserSessionTrigger.accept((username, email, password.toNilIfEmpty(), avatarURL, bio))
@@ -104,11 +112,13 @@ private extension EditProfileViewModel {
     func updateCurrentUserTriggered(owner: EditProfileViewModel, inputs: UpdateCurrentUserParams) -> Observable<Void> {
         updateCurrentUserUseCase
             .execute(
-                username: inputs.username,
-                email: inputs.email,
-                password: inputs.password,
-                image: inputs.avatarURL,
-                bio: inputs.bio
+                params: UpdateCurrentUserParameters(
+                    username: inputs.username,
+                    email: inputs.email,
+                    password: inputs.password,
+                    image: inputs.avatarURL,
+                    bio: inputs.bio
+                )
             )
             .do(
                 onError: { error in

--- a/NimbleMedium/Sources/Presentation/Modules/EditProfile/EditProfileViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditProfile/EditProfileViewModel.swift
@@ -1,0 +1,136 @@
+//
+//  EditProfileViewModel.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 13/10/2021.
+//
+
+import RxSwift
+import RxCocoa
+import Combine
+import Resolver
+
+// sourcery: AutoMockable
+protocol EditProfileViewModelInput {
+
+    func didTapUpdateButton(
+        username: String, email: String, password: String, avatarURL: String, bio: String
+    )
+    func getCurrentUserProfile()
+}
+
+protocol EditProfileViewModelOutput {
+
+    var didUpdateProfile: Signal<Void> { get }
+    var editProfileUIModel: Driver<EditProfileView.UIModel> { get }
+    var errorMessage: Signal<String> { get }
+    var isLoading: Driver<Bool> { get }
+}
+
+protocol EditProfileViewModelProtocol: ObservableViewModel {
+
+    var input: EditProfileViewModelInput { get }
+    var output: EditProfileViewModelOutput { get }
+}
+
+final class EditProfileViewModel: ObservableObject, EditProfileViewModelProtocol {
+
+    typealias UpdateCurrentUserParams = (
+        username: String, email: String, password: String?, avatarURL: String, bio: String
+    )
+    
+    private let disposeBag = DisposeBag()
+
+    var input: EditProfileViewModelInput { self }
+    var output: EditProfileViewModelOutput { self }
+
+    @PublishRelayProperty var didUpdateProfile: Signal<Void>
+    @PublishRelayProperty var errorMessage: Signal<String>
+
+    @BehaviorRelayProperty(false) var isLoading: Driver<Bool>
+    @BehaviorRelayProperty(EditProfileView.UIModel()) var editProfileUIModel: Driver<EditProfileView.UIModel>
+
+    @Injected var getCurrentUserUseCase: GetCurrentUserUseCaseProtocol
+    @Injected var updateCurrentUserUseCase: UpdateCurrentUserUseCaseProtocol
+
+    private let getCurrentUserTrigger = PublishRelay<Void>()
+    private let updateCurrentUserSessionTrigger = PublishRelay<UpdateCurrentUserParams>()
+
+    init() {
+        getCurrentUserTrigger
+            .withUnretained(self)
+            .flatMapLatest { owner, _ in owner.getCurrentUserTriggered(owner: owner) }
+            .subscribe()
+            .disposed(by: disposeBag)
+        
+        updateCurrentUserSessionTrigger
+            .withUnretained(self)
+            .flatMapLatest { owner, inputs in owner.updateCurrentUserTriggered(owner: owner, inputs: inputs) }
+            .subscribe()
+            .disposed(by: disposeBag)
+    }
+}
+
+extension EditProfileViewModel: EditProfileViewModelInput {
+
+    func getCurrentUserProfile() {
+        getCurrentUserTrigger.accept(())
+    }
+
+    func didTapUpdateButton(
+        username: String, email: String, password: String, avatarURL: String, bio: String
+    ) {
+        $isLoading.accept(true)
+        updateCurrentUserSessionTrigger.accept((username, email, password.toNilIfEmpty(), avatarURL, bio))
+    }
+}
+
+extension EditProfileViewModel: EditProfileViewModelOutput { }
+
+private extension EditProfileViewModel {
+
+    func getCurrentUserTriggered(owner: EditProfileViewModel) -> Observable<Void> {
+        getCurrentUserUseCase
+            .execute()
+            .do(
+                onSuccess: { owner.$editProfileUIModel.accept(owner.generateUIModel(fromUser: $0)) },
+                onError: { error in owner.$errorMessage.accept(error.detail) }
+            )
+            .asObservable()
+            .mapToVoid()
+            .catchAndReturn(())
+    }
+
+    func updateCurrentUserTriggered(owner: EditProfileViewModel, inputs: UpdateCurrentUserParams) -> Observable<Void> {
+        updateCurrentUserUseCase
+            .execute(
+                username: inputs.username,
+                email: inputs.email,
+                password: inputs.password,
+                image: inputs.avatarURL,
+                bio: inputs.bio
+            )
+            .do(
+                onError: { error in
+                    owner.$isLoading.accept(false)
+                    owner.$errorMessage.accept(error.detail)
+                },
+                onCompleted: {
+                    owner.$isLoading.accept(false)
+                    owner.$didUpdateProfile.accept(())
+                }
+            )
+            .asObservable()
+            .mapToVoid()
+            .catchAndReturn(())
+    }
+
+    func generateUIModel(fromUser user: User) -> EditProfileView.UIModel {
+        return EditProfileView.UIModel(
+            username: user.username,
+            email: user.email,
+            avatarURL: user.image ?? "",
+            bio: user.bio ?? ""
+        )
+    }
+}

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
@@ -24,6 +24,7 @@ protocol SideMenuActionsViewModelInput {
     func selectSignupOption()
 }
 
+// sourcery: AutoMockable
 protocol SideMenuActionsViewModelOutput {
 
     var didLogout: Signal<Void> { get }
@@ -33,6 +34,7 @@ protocol SideMenuActionsViewModelOutput {
     var isAuthenticated: Driver<Bool> { get }
 }
 
+// sourcery: AutoMockable
 protocol SideMenuActionsViewModelProtocol: ObservableViewModel {
 
     var input: SideMenuActionsViewModelInput { get }

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuHeader/SideMenuHeaderViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuHeader/SideMenuHeaderViewModel.swift
@@ -16,12 +16,14 @@ protocol SideMenuHeaderViewModelInput {
     func selectEditProfileOption()
 }
 
+// sourcery: AutoMockable
 protocol SideMenuHeaderViewModelOutput {
 
     var didSelectEditProfileOption: Signal<Bool> { get }
     var uiModel: Driver<SideMenuHeaderView.UIModel?> { get }
 }
 
+// sourcery: AutoMockable
 protocol SideMenuHeaderViewModelProtocol: ObservableViewModel {
 
     var input: SideMenuHeaderViewModelInput { get }

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuMain/SideMenuView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuMain/SideMenuView.swift
@@ -13,6 +13,7 @@ struct SideMenuView: View {
     @ObservedViewModel private var viewModel: SideMenuViewModelProtocol = Resolver.resolve()
 
     @Injected private var sideMenuActionsViewModel: SideMenuActionsViewModelProtocol
+    @Injected private var sideMenuHeaderViewModel: SideMenuHeaderViewModelProtocol
 
     var body: some View {
         GeometryReader { metrics in
@@ -25,7 +26,10 @@ struct SideMenuView: View {
     }
 
     init() {
-        viewModel.input.bindData(sideMenuActionsViewModel: sideMenuActionsViewModel)
+        viewModel.input.bindData(
+            sideMenuActionsViewModel: sideMenuActionsViewModel,
+            sideMenuHeaderViewModel: sideMenuHeaderViewModel
+        )
     }
 }
 

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuMain/SideMenuViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuMain/SideMenuViewModel.swift
@@ -12,7 +12,10 @@ import RxSwift
 
 protocol SideMenuViewModelInput {
 
-    func bindData(sideMenuActionsViewModel: SideMenuActionsViewModelProtocol)
+    func bindData(
+        sideMenuActionsViewModel: SideMenuActionsViewModelProtocol,
+        sideMenuHeaderViewModel: SideMenuHeaderViewModelProtocol
+    )
 }
 
 protocol SideMenuViewModelOutput {
@@ -38,7 +41,10 @@ final class SideMenuViewModel: ObservableObject, SideMenuViewModelProtocol {
 
 extension SideMenuViewModel: SideMenuViewModelInput {
 
-    func bindData(sideMenuActionsViewModel: SideMenuActionsViewModelProtocol) {
+    func bindData(
+        sideMenuActionsViewModel: SideMenuActionsViewModelProtocol,
+        sideMenuHeaderViewModel: SideMenuHeaderViewModelProtocol
+    ) {
         sideMenuActionsViewModel.output.didLogout.asObservable()
             .withUnretained(self)
             .bind { _ in
@@ -61,6 +67,13 @@ extension SideMenuViewModel: SideMenuViewModelInput {
             .disposed(by: disposeBag)
         
         sideMenuActionsViewModel.output.didSelectSignupOption.asObservable()
+            .withUnretained(self)
+            .bind { _ in
+                self.$didSelectMenuOption.accept(())
+            }
+            .disposed(by: disposeBag)
+
+        sideMenuHeaderViewModel.output.didSelectEditProfileOption.asObservable()
             .withUnretained(self)
             .bind { _ in
                 self.$didSelectMenuOption.accept(())

--- a/NimbleMedium/Sources/Presentation/Views/AppTextView.swift
+++ b/NimbleMedium/Sources/Presentation/Views/AppTextView.swift
@@ -27,15 +27,16 @@ struct AppTextView: UIViewRepresentable {
     func makeUIView(context: UIViewRepresentableContext<Self>) -> UIViewType {
         let textView = UITextView()
         textView.autocapitalizationType = .sentences
+        textView.delegate = context.coordinator
+        textView.font = .preferredFont(forTextStyle: UIFont.TextStyle.body)
         textView.isSelectable = true
+        textView.layer.borderColor = UIColor.lightGray.cgColor
+        textView.layer.borderWidth = 1.0
+        textView.layer.cornerRadius = 8.0
         textView.text = placeholder
         textView.textColor = placeholderTextColor
+        textView.textContainerInset = UIEdgeInsets(top: 8.0, left: 10.0, bottom: 8.0, right: 10.0)
         textView.tintColor = .black
-        textView.font = .preferredFont(forTextStyle: UIFont.TextStyle.body)
-        textView.delegate = context.coordinator
-        textView.layer.cornerRadius = 8.0
-        textView.layer.borderWidth = 1.0
-        textView.layer.borderColor = UIColor.lightGray.cgColor
         return textView
     }
 

--- a/NimbleMedium/Sources/Presentation/Views/AppTextView.swift
+++ b/NimbleMedium/Sources/Presentation/Views/AppTextView.swift
@@ -30,6 +30,7 @@ struct AppTextView: UIViewRepresentable {
         textView.isSelectable = true
         textView.text = placeholder
         textView.textColor = placeholderTextColor
+        textView.tintColor = .black
         textView.font = .preferredFont(forTextStyle: UIFont.TextStyle.body)
         textView.delegate = context.coordinator
         textView.layer.cornerRadius = 8.0
@@ -39,6 +40,10 @@ struct AppTextView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UIViewType, context: UIViewRepresentableContext<Self>) {
+        if !text.wrappedValue.isEmpty {
+            uiView.text = text.wrappedValue
+            uiView.textColor = .black
+        }
         configuration?(uiView)
     }
 
@@ -59,21 +64,19 @@ struct AppTextView: UIViewRepresentable {
         }
 
         func textViewDidChange(_ textView: UITextView) {
-            self.text.wrappedValue = textView.text
+            text.wrappedValue = textView.text
         }
 
         func textViewDidEndEditing(_ textView: UITextView) {
-            if textView.text.isEmpty {
-                textView.text = placeholder
-                textView.textColor = placeholderTextColor
-            }
+            guard textView.text.isEmpty else { return }
+            textView.text = placeholder
+            textView.textColor = placeholderTextColor
         }
 
         func textViewDidBeginEditing(_ textView: UITextView) {
-            if textView.textColor == placeholderTextColor {
-                textView.text = nil
-                textView.textColor = .black
-            }
+            guard textView.textColor == placeholderTextColor else { return }
+            textView.text = nil
+            textView.textColor = .black
         }
     }
 }

--- a/NimbleMedium/Sources/Supports/Extensions/Foundation/JSONDecoder+Default.swift
+++ b/NimbleMedium/Sources/Supports/Extensions/Foundation/JSONDecoder+Default.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Minh Pham on 26/08/2021.
 //
+
 import Foundation
 
 extension JSONDecoder {

--- a/NimbleMedium/Sources/Supports/Extensions/Foundation/String+EmptyCheck.swift
+++ b/NimbleMedium/Sources/Supports/Extensions/Foundation/String+EmptyCheck.swift
@@ -1,0 +1,15 @@
+//
+//  String+EmptyCheck.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 13/10/2021.
+//
+
+import Foundation
+
+extension String {
+
+    func toNilIfEmpty() -> String? {
+        self.isEmpty ? nil : self
+    }
+}

--- a/NimbleMedium/Sources/Supports/Extensions/Foundation/String+EmptyCheck.swift
+++ b/NimbleMedium/Sources/Supports/Extensions/Foundation/String+EmptyCheck.swift
@@ -10,6 +10,6 @@ import Foundation
 extension String {
 
     func toNilIfEmpty() -> String? {
-        self.isEmpty ? nil : self
+        isEmpty ? nil : self
     }
 }

--- a/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
+++ b/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
@@ -47,6 +47,8 @@ extension Resolver {
             .implements(GetCreatedArticlesUseCaseProtocol.self)
         Resolver.mock.register { GetFavouritedArticlesUseCaseProtocolMock() }
             .implements(GetFavouritedArticlesUseCaseProtocol.self)
+        Resolver.mock.register { UpdateCurrentUserUseCaseProtocolMock() }
+        .implements(UpdateCurrentUserUseCaseProtocol.self)
     }
 
     private static func registerViewModels() {

--- a/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
+++ b/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
@@ -29,14 +29,10 @@ extension Resolver {
     }
 
     private static func registerUseCases() {
-        Resolver.mock.register {
-            GetArticleCommentsUseCaseProtocolMock()
-        }
+        Resolver.mock.register { GetArticleCommentsUseCaseProtocolMock() }
         .implements(GetArticleCommentsUseCaseProtocol.self)
         Resolver.mock.register { GetArticleUseCaseProtocolMock() }.implements(GetArticleUseCaseProtocol.self)
-        Resolver.mock.register {
-            GetCurrentSessionUseCaseProtocolMock()
-        }
+        Resolver.mock.register { GetCurrentSessionUseCaseProtocolMock() }
         .implements(GetCurrentSessionUseCaseProtocol.self)
         Resolver.mock.register { GetCurrentUserUseCaseProtocolMock() }.implements(GetCurrentUserUseCaseProtocol.self)
         Resolver.mock.register { GetListArticlesUseCaseProtocolMock() }.implements(GetListArticlesUseCaseProtocol.self)
@@ -44,17 +40,21 @@ extension Resolver {
         Resolver.mock.register { LoginUseCaseProtocolMock() }.implements(LoginUseCaseProtocol.self)
         Resolver.mock.register { LogoutUseCaseProtocolMock() }.implements(LogoutUseCaseProtocol.self)
         Resolver.mock.register { GetCreatedArticlesUseCaseProtocolMock() }
-            .implements(GetCreatedArticlesUseCaseProtocol.self)
+        .implements(GetCreatedArticlesUseCaseProtocol.self)
         Resolver.mock.register { GetFavouritedArticlesUseCaseProtocolMock() }
-            .implements(GetFavouritedArticlesUseCaseProtocol.self)
+        .implements(GetFavouritedArticlesUseCaseProtocol.self)
         Resolver.mock.register { UpdateCurrentUserUseCaseProtocolMock() }
         .implements(UpdateCurrentUserUseCaseProtocol.self)
     }
-
+    
     private static func registerViewModels() {
         Resolver.mock.register { ArticleRowViewModelProtocolMock() }.implements(ArticleRowViewModelProtocol.self)
         Resolver.mock.register { HomeViewModelProtocolMock() }.implements(HomeViewModelProtocol.self)
         Resolver.mock.register { LoginViewModelProtocolMock() }.implements(LoginViewModelProtocol.self)
+        Resolver.mock.register { SideMenuActionsViewModelProtocolMock() }
+        .implements(SideMenuActionsViewModelProtocol.self)
+        Resolver.mock.register { SideMenuHeaderViewModelProtocolMock() }
+        .implements(SideMenuHeaderViewModelProtocol.self)
         Resolver.mock.register { SignupViewModelProtocolMock() }.implements(SignupViewModelProtocol.self)
     }
 }

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/EditProfile/EditProfileViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/EditProfile/EditProfileViewModelSpec.swift
@@ -88,11 +88,15 @@ final class EditProfileViewModelSpec: QuickSpec {
                 context("when updateCurrentUserUseCase return success") {
 
                     beforeEach {
-                        self.updateCurrentUserUseCase.executeUsernameEmailPasswordImageBioReturnValue = .empty()
+                        self.updateCurrentUserUseCase.executeParamsReturnValue = .empty()
 
                         scheduler.scheduleAt(5) {
                             viewModel.input.didTapUpdateButton(
-                                username: "", email: "", password: "", avatarURL: "", bio: ""
+                                username: "",
+                                email: "",
+                                password: "",
+                                avatarURL: "",
+                                bio: ""
                             )
                         }
                     }
@@ -116,12 +120,16 @@ final class EditProfileViewModelSpec: QuickSpec {
                 context("when updateCurrentUserUseCase return failure") {
 
                     beforeEach {
-                        self.updateCurrentUserUseCase.executeUsernameEmailPasswordImageBioReturnValue =
+                        self.updateCurrentUserUseCase.executeParamsReturnValue =
                             .error(TestError.mock)
 
                         scheduler.scheduleAt(5) {
                             viewModel.input.didTapUpdateButton(
-                                username: "", email: "", password: "", avatarURL: "", bio: ""
+                                username: "",
+                                email: "",
+                                password: "",
+                                avatarURL: "",
+                                bio: ""
                             )
                         }
                     }

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/EditProfile/EditProfileViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/EditProfile/EditProfileViewModelSpec.swift
@@ -1,0 +1,147 @@
+//
+//  EditProfileViewModelSpec.swift
+//  NimbleMediumTests
+//
+//  Created by Minh Pham on 13/10/2021.
+//
+
+import Quick
+import Nimble
+import RxNimble
+import RxSwift
+import RxTest
+import Resolver
+
+@testable import NimbleMedium
+
+final class EditProfileViewModelSpec: QuickSpec {
+
+    @LazyInjected var getCurrentUserUseCase: GetCurrentUserUseCaseProtocolMock
+    @LazyInjected var updateCurrentUserUseCase: UpdateCurrentUserUseCaseProtocolMock
+
+    override func spec() {
+        var viewModel: EditProfileViewModelProtocol!
+        var scheduler: TestScheduler!
+        var disposeBag: DisposeBag!
+
+        describe("a EditProfileViewModel") {
+
+            beforeEach {
+                Resolver.registerMockServices()
+                scheduler = TestScheduler(initialClock: 0)
+                disposeBag = DisposeBag()
+                viewModel = EditProfileViewModel()
+            }
+
+            describe("its getCurrentUserProfile() call") {
+
+                context("when getCurrentUserUseCase return success") {
+
+                    let inputUser = APIUserResponse.dummy.user
+
+                    beforeEach {
+                        self.getCurrentUserUseCase.executeReturnValue =
+                            .just(inputUser, on: scheduler, at: 10)
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.getCurrentUserProfile()
+                        }
+                    }
+
+                    it("returns output editProfileUIModel with correct value") {
+                        let expectedValue = EditProfileView.UIModel(
+                            username: inputUser.username,
+                            email: inputUser.email,
+                            avatarURL: inputUser.image ?? "",
+                            bio: inputUser.bio ?? ""
+                        )
+
+                        expect(viewModel.output.editProfileUIModel)
+                            .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                                .next(0, EditProfileView.UIModel()),
+                                .next(10, expectedValue)
+                            ]
+                    }
+                }
+
+                context("when getCurrentUserUseCase return failure") {
+
+                    beforeEach {
+                        self.getCurrentUserUseCase.executeReturnValue =
+                            .error(TestError.mock, on: scheduler, at: 10)
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.getCurrentUserProfile()
+                        }
+                    }
+
+                    it("returns output with the corresponding errorMessage") {
+                        expect(viewModel.output.errorMessage)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .notTo(beEmpty())
+                    }
+                }
+            }
+
+            describe("its didTapUpdateButton() call") {
+
+                context("when updateCurrentUserUseCase return success") {
+
+                    beforeEach {
+                        self.updateCurrentUserUseCase.executeUsernameEmailPasswordImageBioReturnValue = .empty()
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.didTapUpdateButton(
+                                username: "", email: "", password: "", avatarURL: "", bio: ""
+                            )
+                        }
+                    }
+
+                    it("returns output with isLoading as true then false accordingly") {
+                        expect(viewModel.output.isLoading)
+                            .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                                .next(0, false), // Initial state
+                                .next(5, true), // Start loading
+                                .next(5, false) // Loading complete
+                            ]
+                    }
+
+                    it("returns output with didUpdateProfile event") {
+                        expect(viewModel.output.didUpdateProfile)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .notTo(beEmpty())
+                    }
+                }
+
+                context("when updateCurrentUserUseCase return failure") {
+
+                    beforeEach {
+                        self.updateCurrentUserUseCase.executeUsernameEmailPasswordImageBioReturnValue =
+                            .error(TestError.mock)
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.didTapUpdateButton(
+                                username: "", email: "", password: "", avatarURL: "", bio: ""
+                            )
+                        }
+                    }
+
+                    it("returns output with isLoading as true then false accordingly") {
+                        expect(viewModel.output.isLoading)
+                            .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                                .next(0, false), // Initial state
+                                .next(5, true), // Start loading
+                                .next(5, false) // Loading complete
+                            ]
+                    }
+
+                    it("returns output the corresponding errorMessage") {
+                        expect(viewModel.output.errorMessage)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .notTo(beEmpty())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/SideMenu/SideMenuMain/SideMenuViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/SideMenu/SideMenuMain/SideMenuViewModelSpec.swift
@@ -1,0 +1,67 @@
+//
+//  SideMenuViewModelSpec.swift
+//  NimbleMediumTests
+//
+//  Created by Minh Pham on 13/10/2021.
+//
+
+import Quick
+import Nimble
+import RxNimble
+import RxSwift
+import RxTest
+import Resolver
+
+@testable import NimbleMedium
+
+final class SideMenuViewModelSpec: QuickSpec {
+
+    @LazyInjected var sideMenuActionsViewModel: SideMenuActionsViewModelProtocolMock
+    @LazyInjected var sideMenuHeaderViewModel: SideMenuHeaderViewModelProtocolMock
+
+    override func spec() {
+
+        var viewModel: SideMenuViewModel!
+        var scheduler: TestScheduler!
+        var disposeBag: DisposeBag!
+
+        describe("a SideMenuViewModel") {
+
+            beforeEach {
+                Resolver.registerMockServices()
+                scheduler = TestScheduler(initialClock: 0)
+                disposeBag = DisposeBag()
+                viewModel = SideMenuViewModel()
+            }
+
+            describe("its bindData() call") {
+
+                beforeEach {
+                    let sideMenuActionsViewModelOutput = SideMenuActionsViewModelOutputMock()
+                    self.sideMenuActionsViewModel.output = sideMenuActionsViewModelOutput
+                    sideMenuActionsViewModelOutput.underlyingDidLogout = .just(())
+                    sideMenuActionsViewModelOutput.underlyingDidSelectLoginOption = .just(true)
+                    sideMenuActionsViewModelOutput.underlyingDidSelectMyProfileOption = .just(true)
+                    sideMenuActionsViewModelOutput.underlyingDidSelectSignupOption = .just(true)
+
+                    let sideMenuHeaderViewModelOutput = SideMenuHeaderViewModelOutputMock()
+                    self.sideMenuHeaderViewModel.output = sideMenuHeaderViewModelOutput
+                    sideMenuHeaderViewModelOutput.underlyingDidSelectEditProfileOption = .just(true)
+
+                    scheduler.scheduleAt(5) {
+                        viewModel.input.bindData(
+                            sideMenuActionsViewModel: self.sideMenuActionsViewModel,
+                            sideMenuHeaderViewModel: self.sideMenuHeaderViewModel
+                        )
+                    }
+                }
+
+                it("returns with didSelectEditProfileOption event") {
+                    expect(viewModel.output.didSelectMenuOption)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .notTo(beEmpty())
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolved #61

## What happened

When the users logged in the application successfully, they will be able to update their profile details with the `Edit Profile` button in the left menu header from `Home` Screen.

## Insight

- [x] Get the current user profile and populate data on the text fields for the current user in the `Update Profile` screen, including the user avatar url, the username, the user bio, the user email, and the user password.
- [x] If there is no values on the text fields, disable the `Update` button by default.
- [x] When the users update with valid values on the text fields, enable the `Update` button and need to check to disable the button again if the users modifications are clearing all contents in the textfields.
- [x] When the users press the `Update` button, call the API to update user profile and show a native loading indicator in the middle of the screen while doing so.
- [x] When there is an error while updating the current user, show a temporary toast message with text: `Something went wrong. Please try again later.` and just dismiss the loading indicator.
- [x] If the update is successful, store the new user data to the session cache, dismiss the loading indicator and go back to the previous screen.
- [x] Add unit tests for multiple files related to this feature: `EditProfileViewModel` and `SideMenuViewModel `.

## Proof Of Work

https://user-images.githubusercontent.com/70877098/137072395-b593bfff-b39e-4341-9c8f-14366a94ee10.mov

Tests passed for `EditProfileViewModel`:

![Screen Shot 2021-10-13 at 12 23 21](https://user-images.githubusercontent.com/70877098/137072432-b56675b8-e0ce-40ee-8a3c-dbf7a1a23fa8.png)

Tests passed for `SideMenuViewModel `:

![Screen Shot 2021-10-13 at 12 23 07](https://user-images.githubusercontent.com/70877098/137072450-2c612d0a-ab56-43d8-81bd-abfcf6d9edef.png)

