### PR TITLE
[#82] As a user, I can create a new article from the home screen

### DIFF
--- a/NimbleMedium/Sources/Domain/UseCases/User/GetCurrentSessionUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/User/GetCurrentSessionUseCase.swift
@@ -10,7 +10,7 @@ import RxSwift
 // sourcery: AutoMockable
 protocol GetCurrentSessionUseCaseProtocol: AnyObject {
 
-    func getCurrentUserSession() -> Single<User?>
+    func execute() -> Single<User?>
 }
 
 final class GetCurrentSessionUseCase: GetCurrentSessionUseCaseProtocol {
@@ -21,7 +21,7 @@ final class GetCurrentSessionUseCase: GetCurrentSessionUseCaseProtocol {
         self.userSessionRepository = userSessionRepository
     }
 
-    func getCurrentUserSession() -> Single<User?> {
+    func execute() -> Single<User?> {
         userSessionRepository
             .getCurrentUser()
     }

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsView.swift
@@ -16,6 +16,7 @@ struct FeedsView: View {
     
     @State private var isFirstLoad: Bool = true
     @State private var isErrorToastPresented = false
+    @State private var isShowingCreateArticleScreen = false
 
     // TODO: Implement the logic when to show new article ToolbarItem button in integrate task, default to false
     @State private var isAuthenticated = false
@@ -38,27 +39,17 @@ struct FeedsView: View {
                 navigationBarTrailingContent
             }
             .toast(isPresented: $isErrorToastPresented, dismissAfter: 3.0) {
-                ToastView(Localizable.errorGeneric()) { } background: {
-                    Color.clear
-                }
+                ToastView(Localizable.errorGeneric()) { } background: { Color.clear }
             }
-            .onAppear {
-                isSideMenuDraggingEnabled = true
-            }
-            .onDisappear {
-                isSideMenuDraggingEnabled = false
-            }
+            .onAppear { isSideMenuDraggingEnabled = true }
+            .onDisappear { isSideMenuDraggingEnabled = false }
         }
         .accentColor(.white)
-        .onReceive(viewModel.output.didFinishRefresh) { _ in
-            if isFirstLoad {
-                isFirstLoad = false
-            }
-        }
-        .onReceive(viewModel.output.didFailToLoadArticle) { _ in
-            isErrorToastPresented = true
-        }
-        .onAppear { viewModel.input.refresh() }
+        .onReceive(viewModel.output.didFinishRefresh) { _ in if isFirstLoad { isFirstLoad = false } }
+        .onReceive(viewModel.output.didFailToLoadArticle) { _ in isErrorToastPresented = true }
+        .onAppear { viewModel.input.viewOnAppear() }
+        .bind(viewModel.output.isAuthenticated, to: _isAuthenticated)
+        .fullScreenCover(isPresented: $isShowingCreateArticleScreen) { CreateArticleView() }
     }
 
     var navigationBarLeadingContent: some ToolbarContent {
@@ -74,9 +65,7 @@ struct FeedsView: View {
         ToolbarItem(placement: .navigationBarTrailing) {
             if isAuthenticated {
                 Button(
-                    action: {
-                        // TODO: Implement the ToolbarItem action in integrate task
-                    },
+                    action: { isShowingCreateArticleScreen = true },
                     label: { Image(systemName: SystemImageName.plusSquare.rawValue) }
                 )
             }

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsViewModel.swift
@@ -107,7 +107,7 @@ private extension FeedsViewModel {
 
     func getCurrentUserSessionTriggered(owner: FeedsViewModel) -> Observable<Void> {
         getCurrentSessionUseCase
-            .getCurrentUserSession()
+            .execute()
             .map { $0 != nil }
             .do(
                 onSuccess: { owner.$isAuthenticated.accept($0) },

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
@@ -124,7 +124,7 @@ private extension SideMenuActionsViewModel {
 
     func getCurrentUserSessionTriggered(owner: SideMenuActionsViewModel) -> Observable<Void> {
         getCurrentSessionUseCase
-            .getCurrentUserSession()
+            .execute()
             .map { $0 != nil }
             .do(
                 onSuccess: { owner.$isAuthenticated.accept($0) },

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuHeader/SideMenuHeaderViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuHeader/SideMenuHeaderViewModel.swift
@@ -83,7 +83,7 @@ private extension SideMenuHeaderViewModel {
 
     func getCurrentUserSessionTriggered(owner: SideMenuHeaderViewModel) -> Observable<Void> {
         getCurrentSessionUseCase
-            .getCurrentUserSession()
+            .execute()
             .map {
                 guard let user = $0 else { return nil }
                 return owner.generateUIModel(from: user)

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModelSpec.swift
@@ -67,7 +67,7 @@ final class SideMenuActionsViewModelSpec: QuickSpec {
                         let user = UserDummy()
 
                         beforeEach {
-                            self.getCurrentSessionUseCase.getCurrentUserSessionReturnValue =
+                            self.getCurrentSessionUseCase.executeReturnValue =
                                 .just(user, on: scheduler, at: 50)
                             bindData()
                         }
@@ -85,7 +85,7 @@ final class SideMenuActionsViewModelSpec: QuickSpec {
                     context("when getCurrentSessionUseCase returns an invalid user session") {
 
                         beforeEach {
-                            self.getCurrentSessionUseCase.getCurrentUserSessionReturnValue =
+                            self.getCurrentSessionUseCase.executeReturnValue =
                                 .just(nil, on: scheduler, at: 50)
                             bindData()
                         }
@@ -103,7 +103,7 @@ final class SideMenuActionsViewModelSpec: QuickSpec {
                     context("when getCurrentSessionUseCase returns an error getting the user session") {
 
                         beforeEach {
-                            self.getCurrentSessionUseCase.getCurrentUserSessionReturnValue =
+                            self.getCurrentSessionUseCase.executeReturnValue =
                                 .error(TestError.mock, on: scheduler, at: 50)
                             bindData()
                         }

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/SideMenu/SideMenuHeader/SideMenuHeaderViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/SideMenu/SideMenuHeader/SideMenuHeaderViewModelSpec.swift
@@ -48,7 +48,7 @@ final class SideMenuHeaderViewModelSpec: QuickSpec {
                     let user = UserDummy()
 
                     beforeEach {
-                        self.getCurrentSessionUseCase.getCurrentUserSessionReturnValue =
+                        self.getCurrentSessionUseCase.executeReturnValue =
                             .just(user, on: scheduler, at: 50)
                         viewModel.input.bindData(homeViewModel: self.homeViewModel)
                     }
@@ -70,7 +70,7 @@ final class SideMenuHeaderViewModelSpec: QuickSpec {
                 context("when there is an invalid user session") {
 
                     beforeEach {
-                        self.getCurrentSessionUseCase.getCurrentUserSessionReturnValue =
+                        self.getCurrentSessionUseCase.executeReturnValue =
                             .just(nil, on: scheduler, at: 50)
                         viewModel.input.bindData(homeViewModel: self.homeViewModel)
                     }
@@ -88,7 +88,7 @@ final class SideMenuHeaderViewModelSpec: QuickSpec {
                 context("when there is an error getting the user session") {
 
                     beforeEach {
-                        self.getCurrentSessionUseCase.getCurrentUserSessionReturnValue =
+                        self.getCurrentSessionUseCase.executeReturnValue =
                             .error(TestError.mock, on: scheduler, at: 50)
                         viewModel.input.bindData(homeViewModel: self.homeViewModel)
                     }


### PR DESCRIPTION
Resolved #82

## What happened

When the users logged in the application successfully, they can create a new article from the `Home` screen.

## Insight

- [x] Show the create new article button when the users are logged in successfully, otherwise hide it.
- [x] When the users tap on the create new article button in the top right navigation bar of the `Home` screen, navigate to the `New Article` screen.
- [x] Once in the `New Article` screen, the users can tap on the `Back` button to go back to the previous screen.
- [x] Updated unit tests for FeedsViewModel to reflect the new integration logic change.

## Proof Of Work

https://user-images.githubusercontent.com/70877098/137250637-c2be84c7-f5a0-4b55-8b3a-7321742cd557.mov

All new tests are passing:

![Screen Shot 2021-10-14 at 11 15 38](https://user-images.githubusercontent.com/70877098/137250998-28f47989-515e-4600-bf3d-6bb6d1f42c9f.png)


