### PR TITLE
[#81] As a user, I can create a new article

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -76,6 +76,9 @@
 		2497356326D35BBD00177A7C /* MenuOptionButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */; };
 		249D8086270AFD88000775BC /* UserProfileViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249D8085270AFD88000775BC /* UserProfileViewModelSpec.swift */; };
 		24A0EB032716E495009CB9B9 /* CreateArticleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A0EB022716E495009CB9B9 /* CreateArticleView.swift */; };
+		24A2C6FD271D1D44002E4A5A /* CreateArticleUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A2C6FC271D1D44002E4A5A /* CreateArticleUseCase.swift */; };
+		24A2C6FF271D1E1B002E4A5A /* CreateArticleParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A2C6FE271D1E1B002E4A5A /* CreateArticleParameters.swift */; };
+		24A2C701271D1FF7002E4A5A /* Encodable+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A2C700271D1FF7002E4A5A /* Encodable+Dictionary.swift */; };
 		24AB4A662706C4010067CD0D /* ObservableType+Void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AB4A652706C4010067CD0D /* ObservableType+Void.swift */; };
 		24AB4A68270AE58F0067CD0D /* UserProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AB4A67270AE58F0067CD0D /* UserProfileViewModel.swift */; };
 		24B277D32701C1EB00332FEA /* GetUserProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B277D22701C1EB00332FEA /* GetUserProfileUseCase.swift */; };
@@ -297,6 +300,9 @@
 		2497356226D35BBD00177A7C /* MenuOptionButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionButtonStyle.swift; sourceTree = "<group>"; };
 		249D8085270AFD88000775BC /* UserProfileViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewModelSpec.swift; sourceTree = "<group>"; };
 		24A0EB022716E495009CB9B9 /* CreateArticleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateArticleView.swift; sourceTree = "<group>"; };
+		24A2C6FC271D1D44002E4A5A /* CreateArticleUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateArticleUseCase.swift; sourceTree = "<group>"; };
+		24A2C6FE271D1E1B002E4A5A /* CreateArticleParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateArticleParameters.swift; sourceTree = "<group>"; };
+		24A2C700271D1FF7002E4A5A /* Encodable+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Dictionary.swift"; sourceTree = "<group>"; };
 		24AB4A652706C4010067CD0D /* ObservableType+Void.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ObservableType+Void.swift"; sourceTree = "<group>"; };
 		24AB4A67270AE58F0067CD0D /* UserProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewModel.swift; sourceTree = "<group>"; };
 		24B277D22701C1EB00332FEA /* GetUserProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUserProfileUseCase.swift; sourceTree = "<group>"; };
@@ -581,6 +587,7 @@
 		2444C37A27180EB600196035 /* Parameters */ = {
 			isa = PBXGroup;
 			children = (
+				24A2C6FE271D1E1B002E4A5A /* CreateArticleParameters.swift */,
 				2444C3782717D5EA00196035 /* UpdateCurrentUserParameters.swift */,
 			);
 			path = Parameters;
@@ -741,6 +748,7 @@
 		24B277CE2701C06100332FEA /* Article */ = {
 			isa = PBXGroup;
 			children = (
+				24A2C6FC271D1D44002E4A5A /* CreateArticleUseCase.swift */,
 				2D73312A26F0F05D0052DCC7 /* GetArticleUseCase.swift */,
 				2D979C2F270302650084A3F8 /* GetCreatedArticlesUseCase.swift */,
 				2DC224E32702B68A008382E3 /* GetFavouritedArticlesUseCase.swift */,
@@ -934,6 +942,7 @@
 				2D1D727326EB305F00431679 /* DateFormatter+Formats.swift */,
 				2459B31026D74B3100ABCE61 /* JSONDecoder+Default.swift */,
 				241D352D271682B4007F6BA9 /* String+EmptyCheck.swift */,
+				24A2C700271D1FF7002E4A5A /* Encodable+Dictionary.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -2193,6 +2202,7 @@
 				24FB783D26FC3A80007534BE /* UserProfileView+UIModel.swift in Sources */,
 				2D73312926F0EFD20052DCC7 /* APIArticleResponse.swift in Sources */,
 				241B99DE26DF34720041207F /* SignupUseCase.swift in Sources */,
+				24A2C701271D1FF7002E4A5A /* Encodable+Dictionary.swift in Sources */,
 				247717332704192900BF13F2 /* NetworkAPIError.swift in Sources */,
 				246B386F26F87730003173FD /* SideMenuHeaderViewModel.swift in Sources */,
 				2DEFAB19271531F5007C2378 /* UnfollowUserUseCase.swift in Sources */,
@@ -2204,6 +2214,7 @@
 				2D69824426C22DC700860A98 /* R.generated.swift in Sources */,
 				247717352704197C00BF13F2 /* AuthenticatedNetworkAPI.swift in Sources */,
 				2DB04AD726C3A4AC003E65F4 /* Color+UIColor.swift in Sources */,
+				24A2C6FF271D1E1B002E4A5A /* CreateArticleParameters.swift in Sources */,
 				2410D4A127041837009B4A95 /* AuthenticatedInterceptor.swift in Sources */,
 				2497356126D34F3200177A7C /* SideMenuActionsView.swift in Sources */,
 				2459B32826D751E300ABCE61 /* LoginUseCase.swift in Sources */,
@@ -2234,6 +2245,7 @@
 				2D084736270D7AB500DFFF69 /* UserProfileCreatedArticlesTabViewModel.swift in Sources */,
 				24F3D7AA26DCE54C00DE2420 /* CodableUser.swift in Sources */,
 				2D5485BE26CA0D2C00FFE707 /* PublishRelayProperty.swift in Sources */,
+				24A2C6FD271D1D44002E4A5A /* CreateArticleUseCase.swift in Sources */,
 				2459B31C26D74F4700ABCE61 /* AuthRequestConfiguration.swift in Sources */,
 				241D352E271682B4007F6BA9 /* String+EmptyCheck.swift in Sources */,
 				2D17E4F226F07996001D3F90 /* NavigationBarPrimaryStyle.swift in Sources */,

--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -88,6 +88,8 @@
 		24C9393926D89FA300547800 /* AppTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C9393826D89FA300547800 /* AppTextField.swift */; };
 		24C9393B26D8A1A200547800 /* AppSecureField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C9393A26D8A1A200547800 /* AppSecureField.swift */; };
 		24C9393D26D8A26300547800 /* AppMainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C9393C26D8A26300547800 /* AppMainButton.swift */; };
+		24D717F8271D3394009B589C /* CreateArticleUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D717F7271D3394009B589C /* CreateArticleUseCaseSpec.swift */; };
+		24D717FA271D3409009B589C /* CreateArticleParameters+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D717F9271D3409009B589C /* CreateArticleParameters+Dummy.swift */; };
 		24F3D7AA26DCE54C00DE2420 /* CodableUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F3D7A926DCE54C00DE2420 /* CodableUser.swift */; };
 		24F3D7AC26DCE84A00DE2420 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F3D7AB26DCE84A00DE2420 /* Keychain.swift */; };
 		24F3D7AE26DCE85F00DE2420 /* KeychainKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F3D7AD26DCE85F00DE2420 /* KeychainKey.swift */; };
@@ -312,6 +314,8 @@
 		24C9393826D89FA300547800 /* AppTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTextField.swift; sourceTree = "<group>"; };
 		24C9393A26D8A1A200547800 /* AppSecureField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSecureField.swift; sourceTree = "<group>"; };
 		24C9393C26D8A26300547800 /* AppMainButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMainButton.swift; sourceTree = "<group>"; };
+		24D717F7271D3394009B589C /* CreateArticleUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateArticleUseCaseSpec.swift; sourceTree = "<group>"; };
+		24D717F9271D3409009B589C /* CreateArticleParameters+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreateArticleParameters+Dummy.swift"; sourceTree = "<group>"; };
 		24F3D7A926DCE54C00DE2420 /* CodableUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableUser.swift; sourceTree = "<group>"; };
 		24F3D7AB26DCE84A00DE2420 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		24F3D7AD26DCE85F00DE2420 /* KeychainKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainKey.swift; sourceTree = "<group>"; };
@@ -802,6 +806,7 @@
 		24B277D72701C31700332FEA /* Article */ = {
 			isa = PBXGroup;
 			children = (
+				24D717F7271D3394009B589C /* CreateArticleUseCaseSpec.swift */,
 				2DC224E52702BB4C008382E3 /* GetFavouritedArticlesUseCaseSpec.swift */,
 				2D73313026F0F4800052DCC7 /* GetArticleUseCaseSpec.swift */,
 				2D892BAA26E89E4500579856 /* GetListArticlesUseCaseSpec.swift */,
@@ -1209,6 +1214,7 @@
 				2D892BA826E89A6100579856 /* APIArticlesResponse+Dummy.swift */,
 				24B277DB2701C79400332FEA /* APIProfileResponse+Dummy.swift */,
 				2477173C27043E7900BF13F2 /* APIUserResponse+Dummy.swift */,
+				24D717F9271D3409009B589C /* CreateArticleParameters+Dummy.swift */,
 				247FE8AA27193DE500E4AEDE /* UpdateCurrentUserParameters+Dummy.swift */,
 			);
 			path = Models;
@@ -2284,6 +2290,7 @@
 				241A5A282714206E00BC33F1 /* LogoutUseCaseSpec.swift in Sources */,
 				2D1A93AC270FFB45003B2011 /* UserProfileFavouritedArticlesTabViewModelSpec.swift in Sources */,
 				2D79A8FC26EF4A7E007B81D1 /* FeedsViewModelSpec.swift in Sources */,
+				24D717FA271D3409009B589C /* CreateArticleParameters+Dummy.swift in Sources */,
 				2DC224E62702BB4C008382E3 /* GetFavouritedArticlesUseCaseSpec.swift in Sources */,
 				2DEFAB1E271537A3007C2378 /* UserRepositorySpec.swift in Sources */,
 				2D29A70D26F44426001EA24F /* ArticleCommentsViewModelSpec.swift in Sources */,
@@ -2293,6 +2300,7 @@
 				246B387926F8A7D7003173FD /* SideMenuHeaderViewModelSpec.swift in Sources */,
 				24F3D7BE26DE041F00DE2420 /* LoginViewModelSpec.swift in Sources */,
 				2D882EE626F1CF4600DB6560 /* GetArticleCommentsUseCaseSpec.swift in Sources */,
+				24D717F8271D3394009B589C /* CreateArticleUseCaseSpec.swift in Sources */,
 				2D4BB30626FC77B2005FED5F /* ArticleCommentRowViewModelSpec.swift in Sources */,
 				241B99DC26DF23030041207F /* AutoMockable.generated.swift in Sources */,
 				2477173D27043E7900BF13F2 /* APIUserResponse+Dummy.swift in Sources */,

--- a/NimbleMedium/Sources/Data/NetworkAPI/RequestConfigurations/ArticleRequestConfiguration.swift
+++ b/NimbleMedium/Sources/Data/NetworkAPI/RequestConfigurations/ArticleRequestConfiguration.swift
@@ -9,6 +9,7 @@ import Alamofire
 
 enum ArticleRequestConfiguration {
 
+    case createArticle(params: CreateArticleParameters)
     case listArticles(
             tag: String?,
             author: String?,
@@ -25,7 +26,7 @@ extension ArticleRequestConfiguration: RequestConfiguration {
 
     var endpoint: String {
         switch self {
-        case .listArticles:
+        case .createArticle, .listArticles:
             return "/articles"
         case .getArticle(let slug):
             return "articles/\(slug)"
@@ -34,6 +35,8 @@ extension ArticleRequestConfiguration: RequestConfiguration {
 
     var method: HTTPMethod {
         switch self {
+        case .createArticle:
+            return .post
         case .listArticles, .getArticle:
             return .get
         }
@@ -41,6 +44,8 @@ extension ArticleRequestConfiguration: RequestConfiguration {
 
     var parameters: Parameters? {
         switch self {
+        case .createArticle(let params):
+            return ["article": params.dictionary]
         case .listArticles(
                 let tag,
                 let author,
@@ -61,5 +66,12 @@ extension ArticleRequestConfiguration: RequestConfiguration {
         }
     }
 
-    var encoding: ParameterEncoding { URLEncoding.queryString }
+    var encoding: ParameterEncoding {
+        switch self {
+        case .createArticle:
+            return URLEncoding.default
+        default:
+            return URLEncoding.queryString
+        }
+    }
 }

--- a/NimbleMedium/Sources/Data/NetworkAPI/RequestConfigurations/AuthRequestConfiguration.swift
+++ b/NimbleMedium/Sources/Data/NetworkAPI/RequestConfigurations/AuthRequestConfiguration.swift
@@ -61,15 +61,7 @@ extension AuthRequestConfiguration: RequestConfiguration {
         case .getCurrentUser:
             return nil
         case .updateCurrentUser(let params):
-            return [
-                "user": [
-                    "username": params.username,
-                    "email": params.email,
-                    "password": params.password,
-                    "image": params.image,
-                    "bio": params.bio
-                ].compactMapValues { $0 }
-            ]
+            return ["user": params.dictionary]
         }
     }
 

--- a/NimbleMedium/Sources/Data/Repositories/Article/ArticleRepository.swift
+++ b/NimbleMedium/Sources/Data/Repositories/Article/ArticleRepository.swift
@@ -9,10 +9,23 @@ import RxSwift
 
 final class ArticleRepository: ArticleRepositoryProtocol {
 
+    private let authenticatedNetworkAPI: AuthenticatedNetworkAPIProtocol
     private let networkAPI: NetworkAPIProtocol
 
-    init(networkAPI: NetworkAPIProtocol) {
+    init(
+        authenticatedNetworkAPI: AuthenticatedNetworkAPIProtocol,
+        networkAPI: NetworkAPIProtocol
+    ) {
+        self.authenticatedNetworkAPI = authenticatedNetworkAPI
         self.networkAPI = networkAPI
+    }
+
+    func createArticle(params: CreateArticleParameters) -> Single<Article> {
+        let requestConfiguration = ArticleRequestConfiguration.createArticle(params: params)
+
+        return authenticatedNetworkAPI
+            .performRequest(requestConfiguration, for: APIArticleResponse.self)
+            .map { $0.article as Article }
     }
 
     func listArticles(

--- a/NimbleMedium/Sources/Domain/Parameters/CreateArticleParameters.swift
+++ b/NimbleMedium/Sources/Domain/Parameters/CreateArticleParameters.swift
@@ -1,0 +1,15 @@
+//
+//  CreateArticleParameters.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 18/10/2021.
+//
+
+import Foundation
+
+struct CreateArticleParameters: Encodable {
+    let title: String
+    let description: String
+    let body: String
+    let tagList: [String]
+}

--- a/NimbleMedium/Sources/Domain/Parameters/CreateArticleParameters.swift
+++ b/NimbleMedium/Sources/Domain/Parameters/CreateArticleParameters.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct CreateArticleParameters: Encodable {
+
     let title: String
     let description: String
     let body: String

--- a/NimbleMedium/Sources/Domain/Parameters/UpdateCurrentUserParameters.swift
+++ b/NimbleMedium/Sources/Domain/Parameters/UpdateCurrentUserParameters.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct UpdateCurrentUserParameters: Encodable {
+
     let username: String
     let email: String
     let password: String?

--- a/NimbleMedium/Sources/Domain/Parameters/UpdateCurrentUserParameters.swift
+++ b/NimbleMedium/Sources/Domain/Parameters/UpdateCurrentUserParameters.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct UpdateCurrentUserParameters {
+struct UpdateCurrentUserParameters: Encodable {
     let username: String
     let email: String
     let password: String?

--- a/NimbleMedium/Sources/Domain/Repositories/Article/ArticleRepositoryProtocol.swift
+++ b/NimbleMedium/Sources/Domain/Repositories/Article/ArticleRepositoryProtocol.swift
@@ -10,6 +10,8 @@ import RxSwift
 // sourcery: AutoMockable
 protocol ArticleRepositoryProtocol: AnyObject {
 
+    func createArticle(params: CreateArticleParameters) -> Single<Article>
+
     func listArticles(
         tag: String?,
         author: String?,

--- a/NimbleMedium/Sources/Domain/UseCases/Article/CreateArticleUseCase.swift
+++ b/NimbleMedium/Sources/Domain/UseCases/Article/CreateArticleUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  CreateArticleUseCase.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 18/10/2021.
+//
+
+import RxSwift
+
+// sourcery: AutoMockable
+protocol CreateArticleUseCaseProtocol {
+
+    func execute(params: CreateArticleParameters) -> Single<Article>
+}
+
+final class CreateArticleUseCase: CreateArticleUseCaseProtocol {
+
+    private let articleRepository: ArticleRepositoryProtocol
+
+    init(articleRepository: ArticleRepositoryProtocol) {
+        self.articleRepository = articleRepository
+    }
+
+    func execute(params: CreateArticleParameters) -> Single<Article> {
+        articleRepository.createArticle(params: params)
+    }
+}

--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -32,7 +32,10 @@ extension Resolver: ResolverRegistering {
             )
         }.implements(AuthRepositoryProtocol.self)
         register {
-            ArticleRepository(networkAPI: resolve())
+            ArticleRepository(
+                authenticatedNetworkAPI: resolve(),
+                networkAPI: resolve()
+            )
         }.implements(ArticleRepositoryProtocol.self)
         register {
             ArticleCommentRepository(
@@ -56,6 +59,9 @@ extension Resolver: ResolverRegistering {
         register {
             CreateArticleCommentUseCase(articleCommentRepository: resolve())
         }.implements(CreateArticleCommentUseCaseProtocol.self)
+        register {
+            CreateArticleUseCase(articleRepository: resolve())
+        }.implements(CreateArticleUseCaseProtocol.self)
         register {
             GetArticleCommentsUseCase(articleCommentRepository: resolve())
         }.implements(GetArticleCommentsUseCaseProtocol.self)

--- a/NimbleMedium/Sources/Supports/Extensions/Foundation/Encodable+Dictionary.swift
+++ b/NimbleMedium/Sources/Supports/Extensions/Foundation/Encodable+Dictionary.swift
@@ -1,0 +1,17 @@
+//
+//  Encodable+Dictionary.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 18/10/2021.
+//
+
+import Foundation
+
+extension Encodable {
+
+    var dictionary: [String: Any] {
+        guard let data = try? JSONEncoder().encode(self) else { return [:] }
+        return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments))
+            .flatMap { $0 as? [String: Any] } ?? [:]
+    }
+}

--- a/NimbleMediumTests/Sources/Dummy/Data/Models/CreateArticleParameters+Dummy.swift
+++ b/NimbleMediumTests/Sources/Dummy/Data/Models/CreateArticleParameters+Dummy.swift
@@ -1,0 +1,15 @@
+//
+//  CreateArticleParameters+Dummy.swift
+//  NimbleMediumTests
+//
+//  Created by Minh Pham on 18/10/2021.
+//
+
+@testable import NimbleMedium
+
+extension CreateArticleParameters {
+
+    static let dummy: CreateArticleParameters = {
+        CreateArticleParameters(title: "", description: "", body: "", tagList: [])
+    }()
+}

--- a/NimbleMediumTests/Sources/Specs/Data/Repositories/Article/ArticleRepositorySpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Data/Repositories/Article/ArticleRepositorySpec.swift
@@ -17,6 +17,7 @@ final class ArticleRepositorySpec: QuickSpec {
 
     override func spec() {
         var repository: ArticleRepository!
+        var authenticatedNetworkAPI: AuthenticatedNetworkAPIProtocolMock!
         var networkAPI: NetworkAPIProtocolMock!
         var scheduler: TestScheduler!
         var disposeBag: DisposeBag!
@@ -26,8 +27,61 @@ final class ArticleRepositorySpec: QuickSpec {
             beforeEach {
                 disposeBag = DisposeBag()
                 networkAPI = NetworkAPIProtocolMock()
-                repository = ArticleRepository(networkAPI: networkAPI)
+                authenticatedNetworkAPI = AuthenticatedNetworkAPIProtocolMock()
+                repository = ArticleRepository(
+                    authenticatedNetworkAPI: authenticatedNetworkAPI,
+                    networkAPI: networkAPI
+                )
                 scheduler = TestScheduler(initialClock: 0)
+            }
+
+            describe("its createArticle() call") {
+
+                context("when the request returns success") {
+
+                    var outputArticle: TestableObserver<DecodableArticle>!
+                    let inputResponse = APIArticleResponse.dummy
+
+                    beforeEach {
+                        outputArticle = scheduler.createObserver(DecodableArticle.self)
+                        authenticatedNetworkAPI.setPerformRequestForReturnValue(Single.just(inputResponse))
+                        repository.createArticle(params: CreateArticleParameters.dummy)
+                            .asObservable()
+                            .compactMap { $0 as? DecodableArticle }
+                            .bind(to: outputArticle)
+                            .disposed(by: disposeBag)
+                    }
+
+                    it("returns correct article") {
+                        expect(outputArticle.events.first?.value.element) == inputResponse.article
+                    }
+                }
+
+                context("when the request returns failure") {
+
+                    var outputError: TestableObserver<Error?>!
+
+                    beforeEach {
+                        outputError = scheduler.createObserver(Optional<Error>.self)
+                        authenticatedNetworkAPI.setPerformRequestForReturnValue(
+                            Single<APIArticleResponse>.error(TestError.mock)
+                        )
+                        repository.createArticle(params: CreateArticleParameters.dummy)
+                            .asObservable()
+                            .materialize()
+                            .map { $0.error }
+                            .bind(to: outputError)
+                            .disposed(by: disposeBag)
+                    }
+
+                    it("returns correct error") {
+                        let error = outputError.events.first?.value.element as? TestError
+
+                        expect(outputError.events.count) == 2
+                        expect(error) == TestError.mock
+                        expect(outputError.events.last?.value.isCompleted) == true
+                    }
+                }
             }
 
             describe("its listArticles() call") {

--- a/NimbleMediumTests/Sources/Specs/Domain/UseCases/Article/CreateArticleUseCaseSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Domain/UseCases/Article/CreateArticleUseCaseSpec.swift
@@ -1,0 +1,86 @@
+//
+//  CreateArticleUseCaseSpec.swift
+//  NimbleMediumTests
+//
+//  Created by Minh Pham on 18/10/2021.
+//
+
+import Quick
+import Nimble
+import RxNimble
+import RxSwift
+import RxTest
+
+@testable import NimbleMedium
+
+final class CreateArticleUseCaseSpec: QuickSpec {
+
+    override func spec() {
+        var usecase: CreateArticleUseCase!
+        var articleRepository: ArticleRepositoryProtocolMock!
+        var scheduler: TestScheduler!
+        var disposeBag: DisposeBag!
+
+        describe("an CreateArticleUseCase") {
+
+            beforeEach {
+                disposeBag = DisposeBag()
+                articleRepository = ArticleRepositoryProtocolMock()
+                usecase = CreateArticleUseCase(articleRepository: articleRepository)
+                scheduler = TestScheduler(initialClock: 0)
+            }
+
+            describe("its execute() call") {
+
+                context("when articleRepository.createArticle() returns success") {
+
+                    let inputArticle = APIArticleResponse.dummy.article
+                    var outputArticle: TestableObserver<DecodableArticle>!
+
+                    beforeEach {
+                        outputArticle = scheduler.createObserver(DecodableArticle.self)
+                        articleRepository.createArticleParamsReturnValue = .just(inputArticle)
+
+                        usecase.execute(params: CreateArticleParameters.dummy)
+                            .asObservable()
+                            .compactMap { $0 as? DecodableArticle }
+                            .bind(to: outputArticle)
+                            .disposed(by: disposeBag)
+                    }
+
+                    it("returns correct article") {
+                        expect(outputArticle.events) == [
+                            .next(0, inputArticle),
+                            .completed(0)
+                        ]
+                    }
+                }
+
+                context("when articleRepository.createArticle() returns failure") {
+
+                    var outputError: TestableObserver<Error?>!
+
+                    beforeEach {
+                        outputError = scheduler.createObserver(Optional<Error>.self)
+                        articleRepository.createArticleParamsReturnValue = .error(TestError.mock)
+
+                        usecase.execute(params: CreateArticleParameters.dummy)
+                            .asObservable()
+                            .materialize()
+                            .map { $0.error }
+                            .bind(to: outputError)
+                            .disposed(by: disposeBag)
+                    }
+
+                    it("returns correct error") {
+                        let error = outputError.events.first?.value.element as? TestError
+
+                        expect(outputError.events.count) == 2
+                        expect(error) == TestError.mock
+                        expect(outputError.events.last?.value.isCompleted) == true
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolved #81

## What happened

Once authenticated, the users will be able to publish a newly created article to the server.

## Insight

- [x] Implement the API for creating an article via this [endpoint](https://gothinkster.github.io/realworld/docs/specs/backend-specs/endpoints#create-article).
- [x] Need to provide the new article data in the request body, the accepted fields are: `title`, `description`, `body` and `tagList`. Here is a sample request body:
```
{
  "article": {
    "title": "How to train your dragon",
    "description": "Ever wonder how?",
    "body": "You have to believe",
    "tagList": ["reactjs", "angularjs", "dragons"]
  }
}
````
- [x] Create a usecase for creating an article for later usage in integrate task.
- [x] Parse the response into the corresponding model, here is an example response for creating an article:
```
{
  "article": {
    "slug": "how-to-train-your-dragon",
    "title": "How to train your dragon",
    "description": "Ever wonder how?",
    "body": "It takes a Jacobian",
    "tagList": ["dragons", "training"],
    "createdAt": "2016-02-18T03:22:56.637Z",
    "updatedAt": "2016-02-18T03:48:35.824Z",
    "favorited": false,
    "favoritesCount": 0,
    "author": {
      "username": "jake",
      "bio": "I work at statefarm",
      "image": "https://i.stack.imgur.com/xHWG8.jpg",
      "following": false
    }
  }
}
```
- [x] Added unit tests for CreateArticleUseCase

## Proof Of Work

Sent request:

```
POST 'https://realworld-temp-api.herokuapp.com/api/articles':
cURL:
$ curl -v \
	-X POST \
	-H "Accept-Language: en-VN;q=1.0, vi-VN;q=0.9, th-VN;q=0.8" \
	-H "User-Agent: Nimble Medium - Staging/1.3.0 (co.nimblehq.nimble-medium-stag; build:1; iOS 14.8.0) Alamofire/5.4.4" \
	-H "Accept-Encoding: br;q=1.0, gzip;q=0.9, deflate;q=0.8" \
	-H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
	-H "Authorization: Token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6Im1pbmgxQG5pbWJsZWhxLmNvIiwidXNlcm5hbWUiOiJNaWtleTEiLCJwYXNzd29yZCI6IiQyYSQxMCRZVVZIWk9uZ0M2NDdKNUREeFJPdmdlY3pvYXAwVk9xMzJNL0h3ZThqSG1rcGhoSEtWOTdZRyIsImJpbyI6IkhlbGxvIGV2ZXJ5b25lIiwiaW1hZ2UiOiJodHRwczovL3JlYWx3b3JsZC10ZW1wLWFwaS5oZXJva3VhcHAuY29tL2ltYWdlcy9zbWlsZXktY3lydXMuanBlZyIsImlhdCI6MTYzNDUyOTIxNiwiZXhwIjoxNjM5NzEzMjE2fQ.tL-74UO3jJAK9TiL1f6V1FP_Ml5BmuXMOtxgwbT3_so" \
	-d "article%5Bdescription%5D=description&article%5Bbody%5D=Hello&article%5Btitle%5D=my%20first%20new%20article&article%5BtagList%5D%5B%5D=" \
	"https://realworld-temp-api.herokuapp.com/api/articles"
2021-10-18 11:41:18.247078+0700 Nimble Medium - Staging[7460:5911145] CredStore - performQuery - Error copying matching creds.  Error=-25300, query={
    class = inet;
    "m_Limit" = "m_LimitAll";
    ptcl = htps;
    "r_Attributes" = 1;
    sdmn = "realworld-temp-api.herokuapp.com";
    srvr = "realworld-temp-api.herokuapp.com";
    sync = syna;
}
```

Successful response:

```
---------------------
200 'https://realworld-temp-api.herokuapp.com/api/articles' [1.5652 s]:
Headers: [
  Via: 1.1 vegur
  Date: Mon, 18 Oct 2021 04:41:19 GMT
  X-Powered-By: Express
  Server: Cowboy
  Access-Control-Allow-Origin: *
  Etag: W/"1a5-jfUm5/EdvQYFVCOyX90QeCwbICk"
  Content-Type: application/json; charset=utf-8
  Connection: keep-alive
  Content-Length: 421
]
Body:
{
  "article" : {
    "description" : "description",
    "body" : "Hello",
    "updatedAt" : "2021-10-18T04:41:19.486Z",
    "author" : {
      "bio" : "Hello everyone",
      "username" : "Mikey1",
      "image" : "https:\/\/realworld-temp-api.herokuapp.com\/images\/smiley-cyrus.jpeg"
    },
    "title" : "my first new article",
    "tagList" : [
      ""
    ],
    "favoritedBy" : [

    ],
    "_count" : {
      "favoritedBy" : 0
    },
    "slug" : "my-first-new-article",
    "favoritesCount" : 0,
    "favorited" : false,
    "createdAt" : "2021-10-18T04:41:19.486Z"
  }
}
```

All tests for CreateArticleUseCase are passed:

![Screen Shot 2021-10-18 at 11 56 24](https://user-images.githubusercontent.com/70877098/137671476-c5fabfc8-4eca-429a-a863-c2fe99143864.png)

