### PR TITLE
[#91] As a user, I can delete my article from the article details screen

### DIFF
--- a/NimbleMedium/Resources/en.lproj/Localizable.strings
+++ b/NimbleMedium/Resources/en.lproj/Localizable.strings
@@ -58,6 +58,7 @@
 "menu.option.myProfile" = "My Profile";
 "menu.option.signup" = "Signup";
 
+"popup.confirmDeleteArticle.title" = "Are you sure you want to delete this article?";
 "popup.confirmLogout.title" = "Are you sure you want to logout?";
 
 "signup.haveAccount.title" = "Have an account?";

--- a/NimbleMedium/Sources/Constants/SystemImageName.swift
+++ b/NimbleMedium/Sources/Constants/SystemImageName.swift
@@ -6,9 +6,10 @@
 //
 
 enum SystemImageName: String {
+    
     case chevronBackward = "chevron.backward"
+    case minusSquare = "minus.square"
     case plusSquare = "plus.square"
     case squareAndPencil = "square.and.pencil"
     case xmark
-    case minusSquare = "minus.square"
 }

--- a/NimbleMedium/Sources/Constants/SystemImageName.swift
+++ b/NimbleMedium/Sources/Constants/SystemImageName.swift
@@ -10,4 +10,5 @@ enum SystemImageName: String {
     case plusSquare = "plus.square"
     case squareAndPencil = "square.and.pencil"
     case xmark
+    case minusSquare = "minus.square"
 }

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
@@ -18,6 +18,9 @@ struct ArticleDetailView: View {
     @State private var isErrorToastPresented = false
     @State private var isFetchArticleDetailFailed = false
 
+    // swiftlint:disable identifier_name
+    @State private var isPresentedDeleteArticleConfirmationAlert = false
+
     private let slug: String
 
     var body: some View {
@@ -31,6 +34,7 @@ struct ArticleDetailView: View {
             }
         }
         .navigationTitle(Localizable.articleDetailTitleText())
+        .toolbar { navigationBarTrailingContent }
         .modifier(NavigationBarPrimaryStyle())
         .toast(isPresented: $isErrorToastPresented, dismissAfter: 3.0) {
             ToastView(Localizable.errorGeneric()) {} background: {
@@ -46,6 +50,18 @@ struct ArticleDetailView: View {
             isErrorToastPresented = true
         }
         .bind(viewModel.output.uiModel, to: _uiModel)
+        .alert(isPresented: $isPresentedDeleteArticleConfirmationAlert) {
+            Alert(
+                title: Text(Localizable.popupConfirmDeleteArticleTitle()),
+                primaryButton: .destructive(
+                    Text(Localizable.actionConfirmText()),
+                    action: {
+                        // TODO: Delete Article
+                    }
+                ),
+                secondaryButton: .default(Text(Localizable.actionCancelText()))
+            )
+        }
     }
 
     var comments: some View {
@@ -61,6 +77,15 @@ struct ArticleDetailView: View {
             }
         )
         .padding(.all, 16.0)
+    }
+
+    var navigationBarTrailingContent: some ToolbarContent {
+        ToolbarItem(placement: .navigationBarTrailing) {
+            Button(
+                action: { isPresentedDeleteArticleConfirmationAlert = true },
+                label: { Image(systemName: SystemImageName.minusSquare.rawValue) }
+            )
+        }
     }
 
     init(slug: String) {

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
@@ -19,7 +19,7 @@ struct ArticleDetailView: View {
     @State private var isFetchArticleDetailFailed = false
 
     // swiftlint:disable identifier_name
-    @State private var isPresentedDeleteArticleConfirmationAlert = false
+    @State private var isDeleteArticleConfirmationAlertPresented = false
 
     private let slug: String
 
@@ -50,7 +50,7 @@ struct ArticleDetailView: View {
             isErrorToastPresented = true
         }
         .bind(viewModel.output.uiModel, to: _uiModel)
-        .alert(isPresented: $isPresentedDeleteArticleConfirmationAlert) {
+        .alert(isPresented: $isDeleteArticleConfirmationAlertPresented) {
             Alert(
                 title: Text(Localizable.popupConfirmDeleteArticleTitle()),
                 primaryButton: .destructive(
@@ -82,7 +82,7 @@ struct ArticleDetailView: View {
     var navigationBarTrailingContent: some ToolbarContent {
         ToolbarItem(placement: .navigationBarTrailing) {
             Button(
-                action: { isPresentedDeleteArticleConfirmationAlert = true },
+                action: { isDeleteArticleConfirmationAlertPresented = true },
                 label: { Image(systemName: SystemImageName.minusSquare.rawValue) }
             )
         }


### PR DESCRIPTION
Resolved #91

## What happened

Add delete article details button in Article Detail screen

## Insight

- [x] On the `Article Details` screen UI layout from #19, add a delete article button on the right side of the top navigation bar.
- [x] Use the delete article icon from below resources.
- [x] Hide the button by default.

## Proof Of Work

https://user-images.githubusercontent.com/17875522/139012916-16f27d00-f90b-4748-a2ac-0c7eafdf9aa5.mov


