### PR TITLE
[#94] As a user, I can delete my article from the article details screen

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -190,6 +190,7 @@
 		2D979C322703034C0084A3F8 /* GetCreatedArticlesUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D979C312703034C0084A3F8 /* GetCreatedArticlesUseCaseSpec.swift */; };
 		2DA4ABBF26CF90D000CF7D68 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA4ABBE26CF90D000CF7D68 /* AppEnvironment.swift */; };
 		2DA4ABC126CF91E200CF7D68 /* App+Firebase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA4ABC026CF91E200CF7D68 /* App+Firebase.swift */; };
+		2DAA03EB272A57B400992C7B /* String+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAA03EA272A57B400992C7B /* String+Data.swift */; };
 		2DAF7F1727141C4000C001B8 /* FollowButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAF7F1627141C4000C001B8 /* FollowButton.swift */; };
 		2DB04AD726C3A4AC003E65F4 /* Color+UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB04AD626C3A4AC003E65F4 /* Color+UIColor.swift */; };
 		2DB04AD926C3A6F8003E65F4 /* NimbleMediumUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB04AD826C3A6F8003E65F4 /* NimbleMediumUITests.swift */; };
@@ -433,6 +434,7 @@
 		2DA4ABBB26CF901700CF7D68 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "NimbleMedium/Configurations/Plists/GoogleService/Staging/GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		2DA4ABBE26CF90D000CF7D68 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		2DA4ABC026CF91E200CF7D68 /* App+Firebase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App+Firebase.swift"; sourceTree = "<group>"; };
+		2DAA03EA272A57B400992C7B /* String+Data.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Data.swift"; sourceTree = "<group>"; };
 		2DAF7F1627141C4000C001B8 /* FollowButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowButton.swift; sourceTree = "<group>"; };
 		2DB04AD626C3A4AC003E65F4 /* Color+UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Color+UIColor.swift"; sourceTree = "<group>"; };
 		2DB04AD826C3A6F8003E65F4 /* NimbleMediumUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleMediumUITests.swift; sourceTree = "<group>"; };
@@ -1410,6 +1412,7 @@
 				2D87822E26EB3B3A0080FEF6 /* R.generated.swift */,
 				24F3D7C326DE0FAE00DE2420 /* TestError.swift */,
 				2DEF1FA526E6181F00EB93CC /* Data+Decode.swift */,
+				2DAA03EA272A57B400992C7B /* String+Data.swift */,
 				2D87823026EB3C110080FEF6 /* FileResource+Decode.swift */,
 				2D46FAEF26F830B0005DD323 /* PrimitiveSequenceType+TestScheduler.swift */,
 				2D3FCA102717DC77008C576E /* Completable+TestScheduler.swift */,
@@ -2434,6 +2437,7 @@
 				2422A87927169E980048DBDC /* SideMenuViewModelSpec.swift in Sources */,
 				2D87822F26EB3B3A0080FEF6 /* R.generated.swift in Sources */,
 				24B277D62701C31100332FEA /* GetUserProfileUseCaseSpec.swift in Sources */,
+				2DAA03EB272A57B400992C7B /* String+Data.swift in Sources */,
 				248E13B426F07F5800439BCC /* Resolver+Tests.swift in Sources */,
 				2D46FAF526F87B5D005DD323 /* Expectation+TestableObserver.swift in Sources */,
 				24E986EB272687C20048692D /* DeleteMyArticleUseCaseSpec.swift in Sources */,

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
@@ -71,10 +71,7 @@ struct ArticleDetailView: View {
                 title: Text(Localizable.popupConfirmDeleteArticleTitle()),
                 primaryButton: .destructive(
                     Text(Localizable.actionConfirmText()),
-                    action: {
-                        isLoadingToastPresented = true
-                        viewModel.input.deleteArticle()
-                    }
+                    action: { viewModel.input.deleteArticle() }
                 ),
                 secondaryButton: .default(Text(Localizable.actionCancelText()))
             )

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailViewModel.swift
@@ -123,10 +123,10 @@ extension ArticleDetailViewModel {
             .asObservable()
             .withLatestFrom(
                 getCurrentSessionUseCase.execute(),
-                resultSelector: { ($0, $1) }
+                resultSelector: { article, user in (article, user) }
             )
-            .do(onNext: {
-                owner.$isArticleAuthor.accept($0.author.username == $1?.username)
+            .do(onNext: { article, user in
+                owner.$isArticleAuthor.accept(article.author.username == user?.username)
             })
             .mapToVoid()
             .catchAndReturn(())

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailViewModel.swift
@@ -14,6 +14,7 @@ protocol ArticleDetailViewModelInput {
 
     func fetchArticleDetail()
     func toggleFollowUser()
+    func deleteArticle()
 }
 
 protocol ArticleDetailViewModelOutput {
@@ -22,6 +23,10 @@ protocol ArticleDetailViewModelOutput {
     var didFailToFetchArticleDetail: Signal<Void> { get }
     var didFailToToggleFollow: Signal<Void> { get }
     var uiModel: Driver<ArticleDetailView.UIModel?> { get }
+    var didDeleteArticle: Signal<Void> { get }
+    var didFailToDeleteArticle: Signal<Void> { get }
+    var isLoading: Driver<Bool> { get }
+    var isArticleAuthor: Driver<Bool> { get }
 }
 
 protocol ArticleDetailViewModelProtocol: ObservableViewModel {
@@ -35,16 +40,23 @@ final class ArticleDetailViewModel: ObservableObject, ArticleDetailViewModelProt
     @Injected var getArticleUseCase: GetArticleUseCaseProtocol
     @Injected var followUserUseCase: FollowUserUseCaseProtocol
     @Injected var unfollowUserUseCase: UnfollowUserUseCaseProtocol
+    @Injected var deleteArticleUseCase: DeleteMyArticleUseCaseProtocol
+    @Injected var getCurrentSessionUseCase: GetCurrentSessionUseCaseProtocol
 
     private let disposeBag = DisposeBag()
     private let fetchArticleDetailTrigger = PublishRelay<Void>()
     private let toggleFollowUserTrigger = PublishRelay<Void>()
+    private let deleteArticleTrigger = PublishRelay<Void>()
     private var article: Article?
 
     @PublishRelayProperty var didFetch: Signal<Void>
     @PublishRelayProperty var didFailToFetchArticleDetail: Signal<Void>
     @PublishRelayProperty var didFailToToggleFollow: Signal<Void>
+    @PublishRelayProperty var didDeleteArticle: Signal<Void>
+    @PublishRelayProperty var didFailToDeleteArticle: Signal<Void>
     @BehaviorRelayProperty(nil) var uiModel: Driver<ArticleDetailView.UIModel?>
+    @BehaviorRelayProperty(false) var isLoading: Driver<Bool>
+    @BehaviorRelayProperty(false) var isArticleAuthor: Driver<Bool>
 
     let id: String
     var input: ArticleDetailViewModelInput { self }
@@ -67,6 +79,12 @@ final class ArticleDetailViewModel: ObservableObject, ArticleDetailViewModelProt
             .flatMapLatest { $0.0.toggleFollowUserTriggered(owner: $0.0, following: $0.1) }
             .subscribe()
             .disposed(by: disposeBag)
+
+        deleteArticleTrigger
+            .withUnretained(self)
+            .flatMapLatest { $0.0.deleteArticleTriggered(owner: $0.0) }
+            .subscribe()
+            .disposed(by: disposeBag)
     }
 }
 
@@ -79,6 +97,11 @@ extension ArticleDetailViewModel: ArticleDetailViewModelInput {
     func toggleFollowUser() {
         toggleFollowUserTrigger.accept(())
     }
+
+    func deleteArticle() {
+        $isLoading.accept(true)
+        deleteArticleTrigger.accept(())
+    }
 }
 
 extension ArticleDetailViewModel: ArticleDetailViewModelOutput {}
@@ -88,7 +111,8 @@ extension ArticleDetailViewModel: ArticleDetailViewModelOutput {}
 extension ArticleDetailViewModel {
 
     private func fetchArticleDetailTriggered(owner: ArticleDetailViewModel) -> Observable<Void> {
-        getArticleUseCase.execute(slug: id)
+        getArticleUseCase
+            .execute(slug: id)
             .do(
                 onSuccess: {
                     owner.article = $0
@@ -97,6 +121,13 @@ extension ArticleDetailViewModel {
                 onError: { _ in owner.$didFailToFetchArticleDetail.accept(()) }
             )
             .asObservable()
+            .withLatestFrom(
+                getCurrentSessionUseCase.execute(),
+                resultSelector: { ($0, $1) }
+            )
+            .do(onNext: {
+                owner.$isArticleAuthor.accept($0.author.username == $1?.username)
+            })
             .mapToVoid()
             .catchAndReturn(())
     }
@@ -128,6 +159,23 @@ extension ArticleDetailViewModel {
             .asObservable()
             .mapToVoid()
             .catchAndReturn(()) ?? .empty()
+    }
+
+    private func deleteArticleTriggered(owner: ArticleDetailViewModel) -> Observable<Void> {
+        deleteArticleUseCase.execute(slug: id)
+            .do(
+                onError: { _ in
+                    owner.$isLoading.accept(false)
+                    owner.$didFailToDeleteArticle.accept(())
+                },
+                onCompleted: {
+                    owner.$isLoading.accept(false)
+                    owner.$didDeleteArticle.accept(())
+                }
+            )
+            .asObservable()
+            .mapToVoid()
+            .catchAndReturn(())
     }
 
     private func toggleAuthorFollowing() -> Observable<Bool> {

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsTab/FeedsTabView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsTab/FeedsTabView.swift
@@ -11,7 +11,7 @@ import Resolver
 import SwiftUI
 import ToastUI
 
-struct FeedsTabView: View {
+struct FeedsTabView: View, Equatable {
 
     @ObservedViewModel private var viewModel: FeedsTabViewModelProtocol
 
@@ -39,6 +39,12 @@ struct FeedsTabView: View {
 
     init(viewModel: FeedsTabViewModelProtocol) {
         self.viewModel = viewModel
+    }
+
+    static func == (lhs: FeedsTabView, rhs: FeedsTabView) -> Bool {
+        lhs.isFirstLoad == rhs.isFirstLoad
+            && lhs.isErrorToastPresented == rhs.isErrorToastPresented
+            && lhs.tabType == rhs.tabType
     }
 }
 

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsView.swift
@@ -70,9 +70,9 @@ struct FeedsView: View {
 
     var pagerTabs: some View {
         PagerTabStripView(selection: $selectedTabIndex) {
-            FeedsTabView(viewModel: viewModel.output.yourFeedsViewModel)
+            EquatableView(content: FeedsTabView(viewModel: viewModel.output.yourFeedsViewModel))
                 .pagerTabItem { PagerTabItemTitle(Localizable.feedsYourFeedTabTitle()) }
-            FeedsTabView(viewModel: viewModel.output.globalFeedsViewModel)
+            EquatableView(content: FeedsTabView(viewModel: viewModel.output.globalFeedsViewModel))
                 .pagerTabItem { PagerTabItemTitle(Localizable.feedsGlobalFeedTabTitle()) }
         }
         .pagerTabStripViewStyle(

--- a/NimbleMediumTests/Sources/Dummy/Data/Models/APIUserResponse+Dummy.swift
+++ b/NimbleMediumTests/Sources/Dummy/Data/Models/APIUserResponse+Dummy.swift
@@ -12,4 +12,18 @@ extension APIUserResponse {
     static let dummy: APIUserResponse = {
         R.file.userJson.decoded()
     }()
+
+    static func dummy(with username: String) -> APIUserResponse {
+        """
+        {
+          "user": {
+            "email": "jake@jake.jake",
+            "token": "jwt.token.here",
+            "username": "\(username)",
+            "bio": "I work at statefarm",
+            "image": null
+          }
+        }
+        """.decoded()
+    }
 }

--- a/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
+++ b/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
@@ -57,6 +57,8 @@ extension Resolver {
             .implements(FollowUserUseCaseProtocol.self)
         Resolver.mock.register { UnfollowUserUseCaseProtocolMock() }
             .implements(UnfollowUserUseCaseProtocol.self)
+        Resolver.mock.register { DeleteMyArticleUseCaseProtocolMock() }
+            .implements(DeleteMyArticleUseCaseProtocol.self)
     }
 
     private static func registerViewModels() {

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/ArticleDetail/ArticleDetailViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/ArticleDetail/ArticleDetailViewModelSpec.swift
@@ -33,14 +33,16 @@ final class ArticleDetailViewModelSpec: QuickSpec {
             beforeEach {
                 Resolver.registerMockServices()
                 scheduler = TestScheduler(initialClock: 0)
-
-                SharingScheduler.mock(scheduler: scheduler) {
-                    viewModel = ArticleDetailViewModel(id: "slug")
-                }
                 disposeBag = DisposeBag()
             }
 
             describe("its fetchArticle() call") {
+
+                beforeEach {
+                    SharingScheduler.mock(scheduler: scheduler) {
+                        viewModel = ArticleDetailViewModel(id: "slug")
+                    }
+                }
 
                 context("when GetArticleUseCase return success") {
                     let inputArticle = APIArticleResponse.dummy.article
@@ -129,6 +131,12 @@ final class ArticleDetailViewModelSpec: QuickSpec {
 
                 let inputArticle = APIArticleResponse.dummyWithUnfollowingUser.article
 
+                beforeEach {
+                    SharingScheduler.mock(scheduler: scheduler) {
+                        viewModel = ArticleDetailViewModel(id: "slug")
+                    }
+                }
+
                 context("when it toggles to follow") {
 
                     context("when FollowUserUseCase return success") {
@@ -202,6 +210,10 @@ final class ArticleDetailViewModelSpec: QuickSpec {
 
             describe("its deleteArticle() call") {
 
+                beforeEach {
+                    viewModel = ArticleDetailViewModel(id: "slug")
+                }
+
                 context("when DeleteArticleUseCase return success") {
 
                     beforeEach {
@@ -221,9 +233,9 @@ final class ArticleDetailViewModelSpec: QuickSpec {
                     it("returns output isLoading with correct value") {
                         expect(viewModel.output.isLoading)
                             .events(scheduler: scheduler, disposeBag: disposeBag) == [
-                                .next(1, false),
-                                .next(6, true),
-                                .next(11, false)
+                                .next(0, false),
+                                .next(5, true),
+                                .next(10, false)
                             ]
                     }
                 }
@@ -247,9 +259,9 @@ final class ArticleDetailViewModelSpec: QuickSpec {
                     it("returns output isLoading with correct value") {
                         expect(viewModel.output.isLoading)
                             .events(scheduler: scheduler, disposeBag: disposeBag) == [
-                                .next(1, false),
-                                .next(6, true),
-                                .next(11, false)
+                                .next(0, false),
+                                .next(5, true),
+                                .next(10, false)
                             ]
                     }
                 }

--- a/NimbleMediumTests/Sources/Utilities/String+Data.swift
+++ b/NimbleMediumTests/Sources/Utilities/String+Data.swift
@@ -1,0 +1,24 @@
+//
+//  String+Data.swift
+//  MVVMRxSwiftDemoTests
+//
+//  Created by Bliss on 1/7/21.
+//
+
+import Foundation
+
+extension String {
+
+    var utf8Data: Data {
+        Data(utf8)
+    }
+
+    func decoded<T: Decodable>() -> T {
+
+        guard let object: T = utf8Data.decoded() else {
+            fatalError("Unable to decode from this resource")
+        }
+
+        return object
+    }
+}


### PR DESCRIPTION
Resolved #94

## What happened

Integrate delete article in Article Detail screen

## Insight

- [x] When the users open their own article and enter the `Article Details` screen, show the delete article button, otherwise hide it.
- [x] When the users press the `Delete` button, call the API to delete the article and show a native loading indicator in the middle of the screen while doing so.
- [x] When there is an error while deleting the article, show a temporary toast message with text: `Something went wrong. Please try again later.` and just dismiss the loading indicator.
- [x] If the deletion is successful, dismiss the loading indicator and go back to the `Home` screen.

## Proof Of Work

Success

https://user-images.githubusercontent.com/17875522/139024156-afe4a023-b788-4a0d-9d5f-afdb00b70ac2.mov

Failure

https://user-images.githubusercontent.com/17875522/139024208-16b1558e-2938-47a7-a814-4d9ff6358e1f.mov




