### PR TITLE
[#95] As a user, I can edit my article from the article details screen

### DIFF
--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
@@ -98,11 +98,17 @@ struct ArticleDetailView: View {
     }
 
     var navigationBarTrailingContent: some ToolbarContent {
-        ToolbarItem(placement: .navigationBarTrailing) {
+        ToolbarItemGroup(placement: .navigationBarTrailing) {
             if isArticleAuthor {
                 Button(
                     action: { isDeleteArticleConfirmationAlertPresented = true },
                     label: { Image(systemName: SystemImageName.minusSquare.rawValue) }
+                )
+                Button(
+                    action: {
+                        // TODO: Show Edit Article screen
+                    },
+                    label: { Image(systemName: SystemImageName.squareAndPencil.rawValue) }
                 )
             }
         }


### PR DESCRIPTION
Resolved #95 

## What happened

Add Edit Toolbar Item in Article Detail screen

## Insight

- [x] On the `Article Details` screen UI layout from #19, add an edit button to the top right corner of the article header section as show in the below design.
- [x] Reuse the edit article icon from the UI layout task #39.
- [x] Hide the button by default.

## Proof Of Work

![Screen Shot 2021-10-28 at 14 21 37](https://user-images.githubusercontent.com/17875522/139208901-e3890b9e-cdb8-41e9-878e-2a5ef5a74172.png)

