### PR TITLE
[#86][#48] Add Favourite Button UI

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		2D2F456026C25911002C0331 /* View+NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D2F455F26C25911002C0331 /* View+NavigationBar.swift */; };
 		2D303B3B26C28AC200EEF1C0 /* Constants+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D303B3A26C28AC200EEF1C0 /* Constants+String.swift */; };
 		2D34F40F26FAD8C400C99C6C /* ArticleDetailView+UIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D34F40E26FAD8C400C99C6C /* ArticleDetailView+UIModel.swift */; };
+		2D3829F6272B9C6F00047822 /* FavouriteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3829F5272B9C6F00047822 /* FavouriteButton.swift */; };
 		2D3FCA112717DC77008C576E /* Completable+TestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3FCA102717DC77008C576E /* Completable+TestScheduler.swift */; };
 		2D3FCA132717DE74008C576E /* singleArticleWithFollowingUser.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D3FCA122717DE74008C576E /* singleArticleWithFollowingUser.json */; };
 		2D467C3D26BCD58D008F11E1 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D467C3C26BCD58D008F11E1 /* HomeView.swift */; };
@@ -374,6 +375,7 @@
 		2D2F455F26C25911002C0331 /* View+NavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+NavigationBar.swift"; sourceTree = "<group>"; };
 		2D303B3A26C28AC200EEF1C0 /* Constants+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Constants+String.swift"; sourceTree = "<group>"; };
 		2D34F40E26FAD8C400C99C6C /* ArticleDetailView+UIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleDetailView+UIModel.swift"; sourceTree = "<group>"; };
+		2D3829F5272B9C6F00047822 /* FavouriteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavouriteButton.swift; sourceTree = "<group>"; };
 		2D3FCA102717DC77008C576E /* Completable+TestScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Completable+TestScheduler.swift"; sourceTree = "<group>"; };
 		2D3FCA122717DE74008C576E /* singleArticleWithFollowingUser.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = singleArticleWithFollowingUser.json; sourceTree = "<group>"; };
 		2D467C3C26BCD58D008F11E1 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
@@ -1210,6 +1212,7 @@
 				2D17E4EE26F07738001D3F90 /* AuthorView.swift */,
 				2D469D3E2704430A00B36AD6 /* AvatarView.swift */,
 				2DAF7F1627141C4000C001B8 /* FollowButton.swift */,
+				2D3829F5272B9C6F00047822 /* FavouriteButton.swift */,
 				2D284134271EAB23005B62D6 /* PagerTabItemTitle.swift */,
 			);
 			path = Views;
@@ -2252,6 +2255,7 @@
 				247717372704287B00BF13F2 /* AuthenticatedNetworkAPIProtocol.swift in Sources */,
 				2DEF1F9026E5FE8E00EB93CC /* ArticleRepositoryProtocol.swift in Sources */,
 				2D55E4AE26DF2FA800161052 /* ArticleRow.swift in Sources */,
+				2D3829F6272B9C6F00047822 /* FavouriteButton.swift in Sources */,
 				2D882EEC26F1D47300DB6560 /* ArticleCommentRow.swift in Sources */,
 				2D79A8F826EEFC24007B81D1 /* Date+Format.swift in Sources */,
 				2D303B3B26C28AC200EEF1C0 /* Constants+String.swift in Sources */,

--- a/NimbleMedium/Sources/Constants/SystemImageName.swift
+++ b/NimbleMedium/Sources/Constants/SystemImageName.swift
@@ -12,4 +12,5 @@ enum SystemImageName: String {
     case plusSquare = "plus.square"
     case squareAndPencil = "square.and.pencil"
     case xmark
+    case heartFill = "heart.fill"
 }

--- a/NimbleMedium/Sources/Constants/SystemImageName.swift
+++ b/NimbleMedium/Sources/Constants/SystemImageName.swift
@@ -8,9 +8,9 @@
 enum SystemImageName: String {
     
     case chevronBackward = "chevron.backward"
+    case heartFill = "heart.fill"
     case minusSquare = "minus.square"
     case plusSquare = "plus.square"
     case squareAndPencil = "square.and.pencil"
     case xmark
-    case heartFill = "heart.fill"
 }

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/ArticleRow/ArticleRow.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/ArticleRow/ArticleRow.swift
@@ -19,11 +19,16 @@ struct ArticleRow: View {
         Group {
             if let uiModel = uiModel {
                 VStack(alignment: .leading, spacing: 16.0) {
-                    AuthorView(
-                        articleUpdateAt: uiModel.articleUpdatedAt,
-                        authorName: uiModel.authorName,
-                        authorImage: uiModel.authorImage
-                    )
+                    HStack(alignment: .top) {
+                        AuthorView(
+                            articleUpdateAt: uiModel.articleUpdatedAt,
+                            authorName: uiModel.authorName,
+                            authorImage: uiModel.authorImage
+                        )
+                        Spacer()
+                        // TODO: Update favourite state & action
+                        FavouriteButton(count: 0, isSelected: false) {}
+                    }
                     VStack(alignment: .leading) {
                         Text(uiModel.articleTitle)
                             .fontWeight(.bold)

--- a/NimbleMedium/Sources/Presentation/Views/FavouriteButton.swift
+++ b/NimbleMedium/Sources/Presentation/Views/FavouriteButton.swift
@@ -1,0 +1,44 @@
+//
+//  FavouriteButton.swift
+//  NimbleMedium
+//
+//  Created by Mark G on 29/10/2021.
+//
+
+import SwiftUI
+
+struct FavouriteButton: View {
+
+    private let count: Int
+    private let isSelected: Bool
+    private let action: () -> Void
+
+    var body: some View {
+        Button(action: action, label: {
+            HStack {
+                Text("\(count)")
+                    .foregroundColor(isSelected ? .white : .green)
+                Image(systemName: SystemImageName.heartFill.rawValue)
+                    .foregroundColor(isSelected ? .white : .green)
+            }
+        })
+        .frame(height: 30.0)
+        .padding(.horizontal, 8.0)
+        .background(isSelected ? Color.green : Color.clear)
+        .cornerRadius(4.0)
+        .overlay(
+            RoundedRectangle(cornerRadius: 4.0)
+                .stroke(Color.green, lineWidth: 1.0)
+        )
+    }
+
+    init(
+        count: Int,
+        isSelected: Bool,
+        action: @escaping () -> Void
+    ) {
+        self.count = count
+        self.isSelected = isSelected
+        self.action = action
+    }
+}


### PR DESCRIPTION
Resolved #86

## What happened

Add Favourite Button UI into Home screen & Profile screen

## Insight

- [x] On the `Profile` & `Home` screen, add a favorite button with favorite count text to the top right corner of each article table view cell from #65.
- [x] Reuse the favorite icon, default visibility, and apply the 2 states like from #48.

## Proof Of Work

Home screen
| Normal  | Selected |
| ------------- | ------------- |
| ![Screen Shot 2021-10-29 at 10 32 12](https://user-images.githubusercontent.com/17875522/139372565-b999f54b-8b1d-4a7e-b591-9fed075895de.png) | ![Screen Shot 2021-10-29 at 10 35 17](https://user-images.githubusercontent.com/17875522/139372657-c4934048-7fbe-4a3c-9742-ad35bc8e3efa.png)  |

Favourited screen
| Normal  | Selected |
| ------------- | ------------- |
| ![Screen Shot 2021-10-29 at 10 46 30](https://user-images.githubusercontent.com/17875522/139372767-6750c6d4-c0e0-40dc-ae88-455e7241dd8c.png) | ![Screen Shot 2021-10-29 at 10 43 58](https://user-images.githubusercontent.com/17875522/139372782-3697b1dc-aeb2-473c-ad56-e772d0b16001.png)  |




