### PR TITLE
[#49] Add Favourite Button UI in Article Detail screen

### DIFF
--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
@@ -137,6 +137,8 @@ struct ArticleDetailView: View {
                     FollowButton(isSelected: uiModel.authorIsFollowing) {
                         viewModel.input.toggleFollowUser()
                     }
+                    // TODO: Update favourite state & action
+                    FavouriteButton(count: 0, isSelected: true) {}
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Resolved #49

## What happened

Add Favourite Button UI in Article Detail screen

## Insight

- [x] On the `Article Details` screen UI layout from #19, add a favorite button with favorite count text to the top right corner of the article header section as show in the below design.
- [x] Reuse the favorite icon, default visibility and apply the 2 states from #48.

## Proof Of Work
| Normal  | Selected |
| ------------- | ------------- |
| ![Screen Shot 2021-10-29 at 11 01 03](https://user-images.githubusercontent.com/17875522/139386924-832bb40d-abbd-47bf-b779-ca7c5ff6bd3b.png) | ![Screen Shot 2021-10-29 at 11 02 22](https://user-images.githubusercontent.com/17875522/139386893-83d663da-273b-487d-aef5-76caf399ee38.png)  |




