### PR TITLE
[#88] [#90] As a user, I can toggle to update an article as my favorites from the home/profile screen

### DIFF
--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/ArticleRow/ArticleRow+UIModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/ArticleRow/ArticleRow+UIModel.swift
@@ -15,6 +15,10 @@ extension ArticleRow {
         let articleTitle: String
         let articleDescription: String
         let articleUpdatedAt: String
+        let articleFavouriteCount: Int
+        let articleCanFavourite: Bool
+        var articleIsFavorited: Bool = false
+
         let authorImage: URL?
         let authorName: String
     }

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/ArticleRow/ArticleRow+UIModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/ArticleRow/ArticleRow+UIModel.swift
@@ -15,8 +15,8 @@ extension ArticleRow {
         let articleTitle: String
         let articleDescription: String
         let articleUpdatedAt: String
-        let articleFavouriteCount: Int
-        let articleCanFavourite: Bool
+        let articleFavoriteCount: Int
+        let articleCanFavorite: Bool
         var articleIsFavorited: Bool = false
 
         let authorImage: URL?

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/ArticleRow/ArticleRow.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/ArticleRow/ArticleRow.swift
@@ -8,12 +8,14 @@
 import Resolver
 import SDWebImageSwiftUI
 import SwiftUI
+import ToastUI
 
 struct ArticleRow: View {
 
     @ObservedViewModel private var viewModel: ArticleRowViewModelProtocol
 
     @State var uiModel: UIModel?
+    @State private var isErrorToastPresented = false
 
     var body: some View {
         Group {
@@ -26,8 +28,9 @@ struct ArticleRow: View {
                             authorImage: uiModel.authorImage
                         )
                         Spacer()
-                        // TODO: Update favourite state & action
-                        FavouriteButton(count: 0, isSelected: false) {}
+                        if uiModel.articleCanFavourite {
+                            favouriteButton(uiModel: uiModel)
+                        }
                     }
                     VStack(alignment: .leading) {
                         Text(uiModel.articleTitle)
@@ -44,12 +47,29 @@ struct ArticleRow: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .toast(isPresented: $isErrorToastPresented, dismissAfter: 3.0) {
+            ToastView(Localizable.errorGeneric()) {} background: {
+                Color.clear
+            }
+        }
         .onReceive(viewModel.output.uiModel) {
             uiModel = $0
+        }
+        .onReceive(viewModel.output.didFailToToggleFavouriteArticle) {
+            isErrorToastPresented = true
         }
     }
 
     init(viewModel: ArticleRowViewModelProtocol) {
         self.viewModel = viewModel
+    }
+
+    func favouriteButton(uiModel: UIModel) -> some View {
+        FavouriteButton(
+            count: uiModel.articleFavouriteCount,
+            isSelected: uiModel.articleIsFavorited
+        ) {
+            viewModel.input.toggleFavouriteArticle()
+        }
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/ArticleRow/ArticleRow.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/ArticleRow/ArticleRow.swift
@@ -28,7 +28,7 @@ struct ArticleRow: View {
                             authorImage: uiModel.authorImage
                         )
                         Spacer()
-                        if uiModel.articleCanFavourite {
+                        if uiModel.articleCanFavorite {
                             favouriteButton(uiModel: uiModel)
                         }
                     }
@@ -52,9 +52,7 @@ struct ArticleRow: View {
                 Color.clear
             }
         }
-        .onReceive(viewModel.output.uiModel) {
-            uiModel = $0
-        }
+        .bind(viewModel.output.uiModel, to: _uiModel)
         .onReceive(viewModel.output.didFailToToggleFavouriteArticle) {
             isErrorToastPresented = true
         }
@@ -66,7 +64,7 @@ struct ArticleRow: View {
 
     func favouriteButton(uiModel: UIModel) -> some View {
         FavouriteButton(
-            count: uiModel.articleFavouriteCount,
+            count: uiModel.articleFavoriteCount,
             isSelected: uiModel.articleIsFavorited
         ) {
             viewModel.input.toggleFavouriteArticle()

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/ArticleRow/ArticleRowViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/ArticleRow/ArticleRowViewModel.swift
@@ -11,13 +11,17 @@ import RxCocoa
 import RxSwift
 
 // sourcery: AutoMockable
-protocol ArticleRowViewModelInput {}
+protocol ArticleRowViewModelInput {
+
+    func toggleFavouriteArticle()
+}
 
 // sourcery: AutoMockable
 protocol ArticleRowViewModelOutput {
 
     var id: String { get }
     var uiModel: Driver<ArticleRow.UIModel> { get }
+    var didFailToToggleFavouriteArticle: Signal<Void> { get }
 }
 
 // sourcery: AutoMockable
@@ -29,32 +33,101 @@ protocol ArticleRowViewModelProtocol: ObservableViewModel {
 
 final class ArticleRowViewModel: ObservableObject, ArticleRowViewModelProtocol {
 
+    @Injected private var getCurrentSessionUseCase: GetCurrentSessionUseCaseProtocol
+    @Injected private var toggleArticleFavoriteStatusUseCase: ToggleArticleFavoriteStatusUseCaseProtocol
+
     private let disposeBag = DisposeBag()
+    private let toggleFavouriteArticleTrigger = PublishRelay<Void>()
+    private var articleIsFavourite: Bool
 
     var input: ArticleRowViewModelInput { self }
     var output: ArticleRowViewModelOutput { self }
 
-    let uiModel: Driver<ArticleRow.UIModel>
+    @PublishRelayProperty var didFailToToggleFavouriteArticle: Signal<Void>
+
+    let uiModelSubject: BehaviorRelay<ArticleRow.UIModel?> = .init(value: nil)
     let id: String
+    var uiModel: Driver<ArticleRow.UIModel> {
+        uiModelSubject
+            .compactMap { $0 }
+            .asDriver(onErrorDriveWith: .empty())
+    }
 
     init(article: Article) {
         id = article.id
-        uiModel = .just(
-            .init(
-                id: article.id,
-                articleTitle: article.title,
-                articleDescription: article.description,
-                articleUpdatedAt: article.updatedAt.format(with: .monthDayYear),
-                authorImage: try? article.author.image?.asURL(),
-                authorName: article.author.username
-            )
-        )
+        articleIsFavourite = article.favorited
+
+        getCurrentSessionUseCase.execute()
+            .subscribe(with: self) { owner, user in
+                owner.uiModelSubject.accept(
+                    .init(
+                        id: article.id,
+                        articleTitle: article.title,
+                        articleDescription: article.description,
+                        articleUpdatedAt: article.updatedAt.format(with: .monthDayYear),
+                        articleFavouriteCount: article.favoritesCount,
+                        articleCanFavourite: user?.username != article.author.username,
+                        authorImage: try? article.author.image?.asURL(),
+                        authorName: article.author.username
+                    )
+                )
+            }
+            .disposed(by: disposeBag)
+
+        toggleFavouriteArticleTrigger
+            .withUnretained(self)
+            .flatMap { $0.0.updateToggleFavouriteArticle() }
+            .debounce(.milliseconds(500), scheduler: SharingScheduler.make())
+            .withUnretained(self)
+            .flatMapLatest { $0.0.toggleFavouriteArticleTriggered(owner: $0.0, isFavourite: $0.1) }
+            .subscribe()
+            .disposed(by: disposeBag)
     }
 }
 
-extension ArticleRowViewModel: ArticleRowViewModelInput {}
+extension ArticleRowViewModel: ArticleRowViewModelInput {
+
+    func toggleFavouriteArticle() {
+        toggleFavouriteArticleTrigger.accept(())
+    }
+}
 
 extension ArticleRowViewModel: ArticleRowViewModelOutput {}
+
+// MARK: - Private
+
+extension ArticleRowViewModel {
+
+    private func toggleFavouriteArticleTriggered(owner: ArticleRowViewModel, isFavourite: Bool) -> Observable<Void> {
+        toggleArticleFavoriteStatusUseCase
+            .execute(slug: id, isFavorite: isFavourite)
+            .do(
+                onError: { _ in
+                    owner.$didFailToToggleFavouriteArticle.accept(())
+                    owner.updateFavouriteArticle(owner.articleIsFavourite)
+                },
+                onCompleted: {
+                    owner.articleIsFavourite = isFavourite
+                }
+            )
+            .asObservable()
+            .mapToVoid()
+            .catchAndReturn(())
+    }
+
+    private func updateToggleFavouriteArticle() -> Observable<Bool> {
+        guard let uiModel = uiModelSubject.value else { return .empty() }
+        updateFavouriteArticle(!uiModel.articleIsFavorited)
+
+        return .just(!uiModel.articleIsFavorited)
+    }
+
+    private func updateFavouriteArticle(_ value: Bool) {
+        var uiModel = uiModelSubject.value
+        uiModel?.articleIsFavorited = value
+        uiModelSubject.accept(uiModel)
+    }
+}
 
 extension Array where Element == Article {
 

--- a/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
+++ b/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
@@ -59,6 +59,8 @@ extension Resolver {
             .implements(UnfollowUserUseCaseProtocol.self)
         Resolver.mock.register { DeleteMyArticleUseCaseProtocolMock() }
             .implements(DeleteMyArticleUseCaseProtocol.self)
+        Resolver.mock.register { ToggleArticleFavoriteStatusUseCaseProtocolMock() }
+            .implements(ToggleArticleFavoriteStatusUseCaseProtocol.self)
     }
 
     private static func registerViewModels() {

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/ArticleRow/ArticleRowViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/ArticleRow/ArticleRowViewModelSpec.swift
@@ -37,8 +37,8 @@ final class ArticleRowViewModelSpec: QuickSpec {
                     articleTitle: article.title,
                     articleDescription: article.description,
                     articleUpdatedAt: article.updatedAt.format(with: .monthDayYear),
-                    articleFavouriteCount: article.favoritesCount,
-                    articleCanFavourite: false,
+                    articleFavoriteCount: article.favoritesCount,
+                    articleCanFavorite: false,
                     authorImage: try? article.author.image?.asURL(),
                     authorName: article.author.username
                 )
@@ -80,11 +80,11 @@ final class ArticleRowViewModelSpec: QuickSpec {
                     it("returns output uiModel with correct articleIsFavorited value") {
                         expect(
                             viewModel.output.uiModel
-                                .map { $0.articleIsFavorited }
+                                .map { $0?.articleIsFavorited }
                         )
                         .events(scheduler: scheduler, disposeBag: disposeBag) == [
-                            .next(0, false),
-                            .next(5, !article.favorited)
+                            .next(1, false),
+                            .next(6, !article.favorited)
                         ]
                     }
                 }
@@ -112,12 +112,12 @@ final class ArticleRowViewModelSpec: QuickSpec {
                     it("reverts articleIsFavorited value") {
                         expect(
                             viewModel.output.uiModel
-                                .map { $0.articleIsFavorited }
+                                .map { $0?.articleIsFavorited }
                         )
                         .events(scheduler: scheduler, disposeBag: disposeBag) == [
-                            .next(0, false),
-                            .next(5, !article.favorited),
-                            .next(10, article.favorited)
+                            .next(1, false),
+                            .next(6, !article.favorited),
+                            .next(11, article.favorited)
                         ]
                     }
                 }

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/ArticleRow/ArticleRowViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/ArticleRow/ArticleRowViewModelSpec.swift
@@ -8,6 +8,7 @@
 import Nimble
 import Quick
 import Resolver
+import RxCocoa
 import RxNimble
 import RxSwift
 import RxTest
@@ -16,26 +17,34 @@ import RxTest
 
 final class ArticleRowViewModelSpec: QuickSpec {
 
+    @LazyInjected var toggleArticleFavoriteStatusUseCase: ToggleArticleFavoriteStatusUseCaseProtocolMock
+    @LazyInjected var getCurrentSessionUseCase: GetCurrentSessionUseCaseProtocolMock
+
     override func spec() {
         var viewModel: ArticleRowViewModelProtocol!
         var scheduler: TestScheduler!
         var disposeBag: DisposeBag!
         var uiModel: ArticleRow.UIModel!
+        let article = APIArticleResponse.dummy.article
 
         describe("a FeedsViewModel") {
 
             beforeEach {
                 Resolver.registerMockServices()
 
-                let article = APIArticleResponse.dummy.article
                 uiModel = ArticleRow.UIModel(
                     id: article.id,
                     articleTitle: article.title,
                     articleDescription: article.description,
                     articleUpdatedAt: article.updatedAt.format(with: .monthDayYear),
+                    articleFavouriteCount: article.favoritesCount,
+                    articleCanFavourite: false,
                     authorImage: try? article.author.image?.asURL(),
                     authorName: article.author.username
                 )
+
+                let user = APIUserResponse.dummy.user
+                self.getCurrentSessionUseCase.executeReturnValue = .just(user)
 
                 viewModel = ArticleRowViewModel(article: article)
                 scheduler = TestScheduler(initialClock: 0)
@@ -45,9 +54,73 @@ final class ArticleRowViewModelSpec: QuickSpec {
             it("returns output model with correct value") {
                 expect(viewModel.output.uiModel)
                     .events(scheduler: scheduler, disposeBag: disposeBag) == [
-                        .next(0, uiModel),
-                        .completed(0)
+                        .next(0, uiModel)
                     ]
+            }
+
+            describe("its toggleFavouriteArticle() call") {
+
+                beforeEach {
+                    SharingScheduler.mock(scheduler: scheduler) {
+                        viewModel = ArticleRowViewModel(article: article)
+                    }
+                }
+
+                context("when ToggleArticleFavoriteStatusUseCase return success") {
+
+                    beforeEach {
+                        self.toggleArticleFavoriteStatusUseCase
+                            .executeSlugIsFavoriteReturnValue = .empty(on: scheduler, at: 10)
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.toggleFavouriteArticle()
+                        }
+                    }
+
+                    it("returns output uiModel with correct articleIsFavorited value") {
+                        expect(
+                            viewModel.output.uiModel
+                                .map { $0.articleIsFavorited }
+                        )
+                        .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                            .next(0, false),
+                            .next(5, !article.favorited)
+                        ]
+                    }
+                }
+
+                context("when ToggleArticleFavoriteStatusUseCase return failure") {
+
+                    beforeEach {
+                        self.toggleArticleFavoriteStatusUseCase.executeSlugIsFavoriteReturnValue = .error(
+                            TestError.mock,
+                            on: scheduler,
+                            at: 10
+                        )
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.toggleFavouriteArticle()
+                        }
+                    }
+
+                    it("returns output didFailToToggleFavouriteArticle with signal") {
+                        expect(viewModel.output.didFailToToggleFavouriteArticle)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .notTo(beEmpty())
+                    }
+
+                    it("reverts articleIsFavorited value") {
+                        expect(
+                            viewModel.output.uiModel
+                                .map { $0.articleIsFavorited }
+                        )
+                        .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                            .next(0, false),
+                            .next(5, !article.favorited),
+                            .next(10, article.favorited)
+                        ]
+                    }
+                }
             }
         }
     }

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsTab/FeedsTabViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsTab/FeedsTabViewModelSpec.swift
@@ -38,8 +38,8 @@ final class FeedsTabViewModelSpec: QuickSpec {
                         articleTitle: article.title,
                         articleDescription: article.description,
                         articleUpdatedAt: article.updatedAt.format(with: .monthDayYear),
-                        articleFavouriteCount: article.favoritesCount,
-                        articleCanFavourite: false,
+                        articleFavoriteCount: article.favoritesCount,
+                        articleCanFavorite: false,
                         authorImage: try? article.author.image?.asURL(),
                         authorName: article.author.username
                     )

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsTab/FeedsTabViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsTab/FeedsTabViewModelSpec.swift
@@ -38,6 +38,8 @@ final class FeedsTabViewModelSpec: QuickSpec {
                         articleTitle: article.title,
                         articleDescription: article.description,
                         articleUpdatedAt: article.updatedAt.format(with: .monthDayYear),
+                        articleFavouriteCount: article.favoritesCount,
+                        articleCanFavourite: false,
                         authorImage: try? article.author.image?.asURL(),
                         authorName: article.author.username
                     )

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsViewModelSpec.swift
@@ -38,8 +38,8 @@ final class FeedsViewModelSpec: QuickSpec {
                         articleTitle: article.title,
                         articleDescription: article.description,
                         articleUpdatedAt: article.updatedAt.format(with: .monthDayYear),
-                        articleFavouriteCount: article.favoritesCount,
-                        articleCanFavourite: false,
+                        articleFavoriteCount: article.favoritesCount,
+                        articleCanFavorite: false,
                         authorImage: try? article.author.image?.asURL(),
                         authorName: article.author.username
                     )

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsViewModelSpec.swift
@@ -38,6 +38,8 @@ final class FeedsViewModelSpec: QuickSpec {
                         articleTitle: article.title,
                         articleDescription: article.description,
                         articleUpdatedAt: article.updatedAt.format(with: .monthDayYear),
+                        articleFavouriteCount: article.favoritesCount,
+                        articleCanFavourite: false,
                         authorImage: try? article.author.image?.asURL(),
                         authorName: article.author.username
                     )


### PR DESCRIPTION
Resolved #88
Resolved #90

## What happened

Integrate Favourite Button in Home and Profile screen

## Insight

- [x] When the users see the `Home` screen, show the `Favorite` button for each article item if the user are authenticated, otherwise hide it.
- [x] Use the article data for updating the `Favorite` button's favorite count text and its the current favorite status, if the status is `false`, showing the button as `normal` state, else `selected` state.
- [x] When the users tap on the `Favorite` button with the current favorite status is `false`, trigger the API to add the article to favorite, and disable the user interaction for the button while doing so (no visual change).
- [x] When the users tap on the `Favorite` button with the current favorite status is `true`, trigger the API to remove the article from favorite, and disable the user interaction for the button while doing so (no visual change).
- [x] When the API call is successful, update the button UI to the new state accordingly and the new favorite count text.
- [x] If there is any error occurs while making the API call, show a temporary toast message with default text: `Something went wrong. Please try again later.`.
- [x] Enable the user interaction for the `Favorite` button after the API call completes regardless if it is successful or 

## Proof Of Work

Home screen

https://user-images.githubusercontent.com/17875522/139621054-15fd2446-c10e-4205-809f-43cc68647c6a.mov

Profile screen

https://user-images.githubusercontent.com/17875522/139621093-2f0e22d5-b534-412e-b825-e9ce1a16cb27.mov



