### PR TITLE
[#89] Integrate Favourite Button in Article Detail screen

### DIFF
--- a/NimbleMedium/Sources/Constants/SystemImageName.swift
+++ b/NimbleMedium/Sources/Constants/SystemImageName.swift
@@ -6,7 +6,7 @@
 //
 
 enum SystemImageName: String {
-    
+
     case chevronBackward = "chevron.backward"
     case heartFill = "heart.fill"
     case minusSquare = "minus.square"

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView+UIModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView+UIModel.swift
@@ -14,6 +14,8 @@ extension ArticleDetailView {
         let articleTitle: String
         let articleBody: String
         let articleUpdatedAt: String
+        let articleFavouriteCount: Int
+        var articleIsFavorited: Bool = false
         let authorName: String
         let authorImage: URL?
         var authorIsFollowing: Bool
@@ -25,6 +27,8 @@ extension ArticleDetailView {
             authorImage = try? article.author.image?.asURL()
             authorName = article.author.username
             authorIsFollowing = article.author.following
+            articleFavouriteCount = article.favoritesCount
+            articleIsFavorited = article.favorited
         }
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView+UIModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView+UIModel.swift
@@ -14,7 +14,7 @@ extension ArticleDetailView {
         let articleTitle: String
         let articleBody: String
         let articleUpdatedAt: String
-        let articleFavouriteCount: Int
+        let articleFavoriteCount: Int
         var articleIsFavorited: Bool = false
         let authorName: String
         let authorImage: URL?
@@ -27,7 +27,7 @@ extension ArticleDetailView {
             authorImage = try? article.author.image?.asURL()
             authorName = article.author.username
             authorIsFollowing = article.author.following
-            articleFavouriteCount = article.favoritesCount
+            articleFavoriteCount = article.favoritesCount
             articleIsFavorited = article.favorited
         }
     }

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
@@ -6,6 +6,7 @@
 //
 
 import Resolver
+import RxSwift
 import SDWebImageSwiftUI
 import SwiftUI
 import ToastUI
@@ -50,7 +51,13 @@ struct ArticleDetailView: View {
             isErrorToastPresented = true
             isFetchArticleDetailFailed = true
         }
-        .onReceive(viewModel.output.didFailToToggleFollow) { _ in
+        .onReceive(
+            Observable.of(
+                viewModel.output.didFailToToggleFollow,
+                viewModel.output.didFailToToggleFavouriteArticle
+            )
+            .merge()
+        ) { _ in
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 isErrorToastPresented = true
             }
@@ -133,12 +140,7 @@ struct ArticleDetailView: View {
                 HStack {
                     author(uiModel: uiModel)
                     Spacer()
-
-                    FollowButton(isSelected: uiModel.authorIsFollowing) {
-                        viewModel.input.toggleFollowUser()
-                    }
-                    // TODO: Update favourite state & action
-                    FavouriteButton(count: 0, isSelected: true) {}
+                    if !isArticleAuthor { unAuthorButtons(uiModel: uiModel) }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -150,6 +152,20 @@ struct ArticleDetailView: View {
                 .padding(.horizontal, 8.0)
 
             comments
+        }
+    }
+
+    func unAuthorButtons(uiModel: UIModel) -> some View {
+        Group {
+            FollowButton(isSelected: uiModel.authorIsFollowing) {
+                viewModel.input.toggleFollowUser()
+            }
+            FavouriteButton(
+                count: uiModel.articleFavouriteCount,
+                isSelected: uiModel.articleIsFavorited
+            ) {
+                viewModel.input.toggleFavouriteArticle()
+            }
         }
     }
 

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
@@ -140,7 +140,7 @@ struct ArticleDetailView: View {
                 HStack {
                     author(uiModel: uiModel)
                     Spacer()
-                    if !isArticleAuthor { unAuthorButtons(uiModel: uiModel) }
+                    if !isArticleAuthor { interactionButtons(uiModel: uiModel) }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -155,13 +155,13 @@ struct ArticleDetailView: View {
         }
     }
 
-    func unAuthorButtons(uiModel: UIModel) -> some View {
+    func interactionButtons(uiModel: UIModel) -> some View {
         Group {
             FollowButton(isSelected: uiModel.authorIsFollowing) {
                 viewModel.input.toggleFollowUser()
             }
             FavouriteButton(
-                count: uiModel.articleFavouriteCount,
+                count: uiModel.articleFavoriteCount,
                 isSelected: uiModel.articleIsFavorited
             ) {
                 viewModel.input.toggleFavouriteArticle()

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailViewModel.swift
@@ -14,6 +14,7 @@ protocol ArticleDetailViewModelInput {
 
     func fetchArticleDetail()
     func toggleFollowUser()
+    func toggleFavouriteArticle()
     func deleteArticle()
 }
 
@@ -22,6 +23,7 @@ protocol ArticleDetailViewModelOutput {
     var id: String { get }
     var didFailToFetchArticleDetail: Signal<Void> { get }
     var didFailToToggleFollow: Signal<Void> { get }
+    var didFailToToggleFavouriteArticle: Signal<Void> { get }
     var uiModel: Driver<ArticleDetailView.UIModel?> { get }
     var didDeleteArticle: Signal<Void> { get }
     var didFailToDeleteArticle: Signal<Void> { get }
@@ -42,16 +44,20 @@ final class ArticleDetailViewModel: ObservableObject, ArticleDetailViewModelProt
     @Injected var unfollowUserUseCase: UnfollowUserUseCaseProtocol
     @Injected var deleteArticleUseCase: DeleteMyArticleUseCaseProtocol
     @Injected var getCurrentSessionUseCase: GetCurrentSessionUseCaseProtocol
+    @Injected private var toggleArticleFavoriteStatusUseCase: ToggleArticleFavoriteStatusUseCaseProtocol
 
     private let disposeBag = DisposeBag()
     private let fetchArticleDetailTrigger = PublishRelay<Void>()
     private let toggleFollowUserTrigger = PublishRelay<Void>()
+    private let toggleFavouriteArticleTrigger = PublishRelay<Void>()
     private let deleteArticleTrigger = PublishRelay<Void>()
     private var article: Article?
+    private var articleIsFavourite: Bool = false
 
     @PublishRelayProperty var didFetch: Signal<Void>
     @PublishRelayProperty var didFailToFetchArticleDetail: Signal<Void>
     @PublishRelayProperty var didFailToToggleFollow: Signal<Void>
+    @PublishRelayProperty var didFailToToggleFavouriteArticle: Signal<Void>
     @PublishRelayProperty var didDeleteArticle: Signal<Void>
     @PublishRelayProperty var didFailToDeleteArticle: Signal<Void>
     @BehaviorRelayProperty(nil) var uiModel: Driver<ArticleDetailView.UIModel?>
@@ -80,6 +86,15 @@ final class ArticleDetailViewModel: ObservableObject, ArticleDetailViewModelProt
             .subscribe()
             .disposed(by: disposeBag)
 
+        toggleFavouriteArticleTrigger
+            .withUnretained(self)
+            .flatMap { $0.0.updateToggleFavouriteArticle() }
+            .debounce(.milliseconds(500), scheduler: SharingScheduler.make())
+            .withUnretained(self)
+            .flatMapLatest { $0.0.toggleFavouriteArticleTriggered(owner: $0.0, isFavourite: $0.1) }
+            .subscribe()
+            .disposed(by: disposeBag)
+
         deleteArticleTrigger
             .withUnretained(self)
             .flatMapLatest { $0.0.deleteArticleTriggered(owner: $0.0) }
@@ -96,6 +111,10 @@ extension ArticleDetailViewModel: ArticleDetailViewModelInput {
 
     func toggleFollowUser() {
         toggleFollowUserTrigger.accept(())
+    }
+
+    func toggleFavouriteArticle() {
+        toggleFavouriteArticleTrigger.accept(())
     }
 
     func deleteArticle() {
@@ -116,6 +135,7 @@ extension ArticleDetailViewModel {
             .do(
                 onSuccess: {
                     owner.article = $0
+                    owner.articleIsFavourite = $0.favorited
                     owner.$uiModel.accept(.init(article: $0))
                 },
                 onError: { _ in owner.$didFailToFetchArticleDetail.accept(()) }
@@ -188,6 +208,36 @@ extension ArticleDetailViewModel {
     private func updateAuthorFollowing(_ value: Bool) {
         var uiModel = $uiModel.value
         uiModel?.authorIsFollowing = value
+        $uiModel.accept(uiModel)
+    }
+
+    private func toggleFavouriteArticleTriggered(owner: ArticleDetailViewModel, isFavourite: Bool) -> Observable<Void> {
+        toggleArticleFavoriteStatusUseCase
+            .execute(slug: id, isFavorite: isFavourite)
+            .do(
+                onError: { _ in
+                    owner.$didFailToToggleFavouriteArticle.accept(())
+                    owner.updateFavouriteArticle(owner.articleIsFavourite)
+                },
+                onCompleted: {
+                    owner.articleIsFavourite = isFavourite
+                }
+            )
+            .asObservable()
+            .mapToVoid()
+            .catchAndReturn(())
+    }
+
+    private func updateToggleFavouriteArticle() -> Observable<Bool> {
+        guard let uiModel = $uiModel.value else { return .empty() }
+        updateFavouriteArticle(!uiModel.articleIsFavorited)
+
+        return .just(!uiModel.articleIsFavorited)
+    }
+
+    private func updateFavouriteArticle(_ value: Bool) {
+        var uiModel = $uiModel.value
+        uiModel?.articleIsFavorited = value
         $uiModel.accept(uiModel)
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailViewModel.swift
@@ -219,9 +219,7 @@ extension ArticleDetailViewModel {
                     owner.$didFailToToggleFavouriteArticle.accept(())
                     owner.updateFavouriteArticle(owner.articleIsFavourite)
                 },
-                onCompleted: {
-                    owner.articleIsFavourite = isFavourite
-                }
+                onCompleted: { owner.articleIsFavourite = isFavourite }
             )
             .asObservable()
             .mapToVoid()

--- a/NimbleMedium/Sources/Supports/Extensions/SwiftUI/View+OnReceive.swift
+++ b/NimbleMedium/Sources/Supports/Extensions/SwiftUI/View+OnReceive.swift
@@ -17,7 +17,7 @@ extension View {
         _ driver: Driver<Element>,
         perform action: @escaping (Element) -> Void
     ) -> some View {
-        onReceive(driver.publisher.assertNoFailure(), perform: action)
+        onReceive(driver.asObservable(), perform: action)
     }
 
     @inlinable
@@ -25,6 +25,14 @@ extension View {
         _ signal: Signal<Element>,
         perform action: @escaping (Element) -> Void
     ) -> some View {
-        onReceive(signal.publisher.assertNoFailure(), perform: action)
+        onReceive(signal.asObservable(), perform: action)
+    }
+
+    @inlinable
+    func onReceive<Element>(
+        _ observable: Observable<Element>,
+        perform action: @escaping (Element) -> Void
+    ) -> some View {
+        onReceive(observable.publisher.assertNoFailure(), perform: action)
     }
 }


### PR DESCRIPTION
Resolved #89 

## What happened

Integrate Favourite Button in Article Detail screen

## Insight

- [x] When the users see another user `Article Details` screen, show the `Favorite` button if the user are authenticated, otherwise hide it.
- [x] Use the article data for updating the `Favorite` button's favorite count text and its the current favorite status, if the status is `false`, showing the button as `normal` state, else `selected` state.
- [x] When the users tap on the `Favorite` button with the current favorite status is `false`, trigger the API to add the article to favorite, and disable the user interaction for the button while doing so (no visual change).
- [x] When the users tap on the `Favorite` button with the current favorite status is `true`, trigger the API to remove the article from favorite, and disable the user interaction for the button while doing so (no visual change).
- [x] When the API call is successful, update the button UI to the new state accordingly and the new favorite count text.
- [x] If there is any error occurs while making the API call, show a temporary toast message with default text: `Something went wrong. Please try again later.`.
- [x] Enable the user interaction for the `Favorite` button after the API call completes regardless if it is successful or not. 

## Proof Of Work

https://user-images.githubusercontent.com/17875522/139643066-3e0cac57-0b0b-4741-a0cd-af910a958254.mov



