### PR TITLE
[#208] Fix: Home screen won't update tabs when a user login/logout

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -11,8 +11,8 @@
 		240A80302727B074007F06B7 /* UpdateMyArticleParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 240A802F2727B074007F06B7 /* UpdateMyArticleParameters.swift */; };
 		240E218026FC361000EFC3B5 /* UserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 240E217F26FC361000EFC3B5 /* UserProfileView.swift */; };
 		2410D4A127041837009B4A95 /* AuthenticatedInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2410D4A027041837009B4A95 /* AuthenticatedInterceptor.swift */; };
-		2419F8622729325C00511D0F /* ToggleArticleFavoriteStatusUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2419F8612729325C00511D0F /* ToggleArticleFavoriteStatusUseCaseSpec.swift */; };
 		241960DA272F914E00A11657 /* UserSessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241960D9272F914E00A11657 /* UserSessionViewModel.swift */; };
+		2419F8622729325C00511D0F /* ToggleArticleFavoriteStatusUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2419F8612729325C00511D0F /* ToggleArticleFavoriteStatusUseCaseSpec.swift */; };
 		241A5A252713FA9B00BC33F1 /* LogoutUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241A5A242713FA9B00BC33F1 /* LogoutUseCase.swift */; };
 		241A5A282714206E00BC33F1 /* LogoutUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241A5A272714206E00BC33F1 /* LogoutUseCaseSpec.swift */; };
 		241B4EEA26D3B3F4000409CC /* SideMenuActionItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */; };
@@ -74,6 +74,7 @@
 		247717392704329A00BF13F2 /* GetCurrentUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247717382704329A00BF13F2 /* GetCurrentUserUseCase.swift */; };
 		2477173D27043E7900BF13F2 /* APIUserResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2477173C27043E7900BF13F2 /* APIUserResponse+Dummy.swift */; };
 		2477173F27043EAB00BF13F2 /* user.json in Resources */ = {isa = PBXBuildFile; fileRef = 2477173E27043EAB00BF13F2 /* user.json */; };
+		24773123272FE00400F82D63 /* UserSessionViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24773122272FE00400F82D63 /* UserSessionViewModelSpec.swift */; };
 		247CD0F027142A13002D90D1 /* SideMenuActionsViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247CD0EF27142A13002D90D1 /* SideMenuActionsViewModelSpec.swift */; };
 		247FE8AB27193DE500E4AEDE /* UpdateCurrentUserParameters+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247FE8AA27193DE500E4AEDE /* UpdateCurrentUserParameters+Dummy.swift */; };
 		248E13A926F054AD00439BCC /* Resolver+Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248E13A826F054AD00439BCC /* Resolver+Injection.swift */; };
@@ -263,8 +264,8 @@
 		240A802F2727B074007F06B7 /* UpdateMyArticleParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateMyArticleParameters.swift; sourceTree = "<group>"; };
 		240E217F26FC361000EFC3B5 /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
 		2410D4A027041837009B4A95 /* AuthenticatedInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedInterceptor.swift; sourceTree = "<group>"; };
-		2419F8612729325C00511D0F /* ToggleArticleFavoriteStatusUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleArticleFavoriteStatusUseCaseSpec.swift; sourceTree = "<group>"; };
 		241960D9272F914E00A11657 /* UserSessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionViewModel.swift; sourceTree = "<group>"; };
+		2419F8612729325C00511D0F /* ToggleArticleFavoriteStatusUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleArticleFavoriteStatusUseCaseSpec.swift; sourceTree = "<group>"; };
 		241A5A242713FA9B00BC33F1 /* LogoutUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutUseCase.swift; sourceTree = "<group>"; };
 		241A5A272714206E00BC33F1 /* LogoutUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutUseCaseSpec.swift; sourceTree = "<group>"; };
 		241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionItemView.swift; sourceTree = "<group>"; };
@@ -325,6 +326,7 @@
 		247717382704329A00BF13F2 /* GetCurrentUserUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentUserUseCase.swift; sourceTree = "<group>"; };
 		2477173C27043E7900BF13F2 /* APIUserResponse+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIUserResponse+Dummy.swift"; sourceTree = "<group>"; };
 		2477173E27043EAB00BF13F2 /* user.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = user.json; sourceTree = "<group>"; };
+		24773122272FE00400F82D63 /* UserSessionViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionViewModelSpec.swift; sourceTree = "<group>"; };
 		247CD0EF27142A13002D90D1 /* SideMenuActionsViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionsViewModelSpec.swift; sourceTree = "<group>"; };
 		247FE8AA27193DE500E4AEDE /* UpdateCurrentUserParameters+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UpdateCurrentUserParameters+Dummy.swift"; sourceTree = "<group>"; };
 		248E13A826F054AD00439BCC /* Resolver+Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Resolver+Injection.swift"; sourceTree = "<group>"; };
@@ -761,6 +763,14 @@
 				246B387826F8A7D7003173FD /* SideMenuHeaderViewModelSpec.swift */,
 			);
 			path = SideMenuHeader;
+			sourceTree = "<group>";
+		};
+		24773121272FDFF000F82D63 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				24773122272FE00400F82D63 /* UserSessionViewModelSpec.swift */,
+			);
+			path = Shared;
 			sourceTree = "<group>";
 		};
 		247CD0ED271429DB002D90D1 /* SideMenu */ = {
@@ -1416,6 +1426,7 @@
 		2D72E49526C21C3B00861239 /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				24773121272FDFF000F82D63 /* Shared */,
 				2D29A70B26F44415001EA24F /* ArticleComments */,
 				2DB31D4F26F1960B007254B9 /* ArticleDetail */,
 				244137CC271E7C9000A1542D /* CreateArticle */,
@@ -2495,6 +2506,7 @@
 				2DC824BE271FF6890024CFEF /* GetCurrentUserFollowingArticlesUseCaseSpec.swift in Sources */,
 				24B277DC2701C79400332FEA /* APIProfileResponse+Dummy.swift in Sources */,
 				2D882EE426F1CEB600DB6560 /* ArticleCommentRepositorySpec.swift in Sources */,
+				24773123272FE00400F82D63 /* UserSessionViewModelSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		240E218026FC361000EFC3B5 /* UserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 240E217F26FC361000EFC3B5 /* UserProfileView.swift */; };
 		2410D4A127041837009B4A95 /* AuthenticatedInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2410D4A027041837009B4A95 /* AuthenticatedInterceptor.swift */; };
 		2419F8622729325C00511D0F /* ToggleArticleFavoriteStatusUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2419F8612729325C00511D0F /* ToggleArticleFavoriteStatusUseCaseSpec.swift */; };
+		241960DA272F914E00A11657 /* UserSessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241960D9272F914E00A11657 /* UserSessionViewModel.swift */; };
 		241A5A252713FA9B00BC33F1 /* LogoutUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241A5A242713FA9B00BC33F1 /* LogoutUseCase.swift */; };
 		241A5A282714206E00BC33F1 /* LogoutUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241A5A272714206E00BC33F1 /* LogoutUseCaseSpec.swift */; };
 		241B4EEA26D3B3F4000409CC /* SideMenuActionItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */; };
@@ -263,6 +264,7 @@
 		240E217F26FC361000EFC3B5 /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
 		2410D4A027041837009B4A95 /* AuthenticatedInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedInterceptor.swift; sourceTree = "<group>"; };
 		2419F8612729325C00511D0F /* ToggleArticleFavoriteStatusUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleArticleFavoriteStatusUseCaseSpec.swift; sourceTree = "<group>"; };
+		241960D9272F914E00A11657 /* UserSessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionViewModel.swift; sourceTree = "<group>"; };
 		241A5A242713FA9B00BC33F1 /* LogoutUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutUseCase.swift; sourceTree = "<group>"; };
 		241A5A272714206E00BC33F1 /* LogoutUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutUseCaseSpec.swift; sourceTree = "<group>"; };
 		241B4EE926D3B3F4000409CC /* SideMenuActionItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuActionItemView.swift; sourceTree = "<group>"; };
@@ -567,6 +569,14 @@
 				2410D4A027041837009B4A95 /* AuthenticatedInterceptor.swift */,
 			);
 			path = Interceptors;
+			sourceTree = "<group>";
+		};
+		241960D7272F911B00A11657 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				241960D9272F914E00A11657 /* UserSessionViewModel.swift */,
+			);
+			path = Shared;
 			sourceTree = "<group>";
 		};
 		241A5A262714202C00BC33F1 /* Auth */ = {
@@ -1712,6 +1722,7 @@
 		2DB2677E26BBF13400FF05BB /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				241960D7272F911B00A11657 /* Shared */,
 				2D882EE726F1D39000DB6560 /* ArticleComments */,
 				2D9032CE26F04D7B005CA3F5 /* ArticleDetail */,
 				24A0EB012716E469009CB9B9 /* CreateArticle */,
@@ -2391,6 +2402,7 @@
 				24F3D7AA26DCE54C00DE2420 /* CodableUser.swift in Sources */,
 				2D284135271EAB23005B62D6 /* PagerTabItemTitle.swift in Sources */,
 				2D5485BE26CA0D2C00FFE707 /* PublishRelayProperty.swift in Sources */,
+				241960DA272F914E00A11657 /* UserSessionViewModel.swift in Sources */,
 				24A2C6FD271D1D44002E4A5A /* CreateArticleUseCase.swift in Sources */,
 				2459B31C26D74F4700ABCE61 /* AuthRequestConfiguration.swift in Sources */,
 				241D352E271682B4007F6BA9 /* String+EmptyCheck.swift in Sources */,

--- a/NimbleMedium/Sources/Application/App.swift
+++ b/NimbleMedium/Sources/Application/App.swift
@@ -10,9 +10,12 @@ import SwiftUI
 @main
 struct App: SwiftUI.App {
 
+    @StateObject var userSessionViewModel = UserSessionViewModel()
+
     var body: some Scene {
         WindowGroup {
             HomeView()
+                .environmentObject(userSessionViewModel)
         }
     }
 

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsView.swift
@@ -14,12 +14,13 @@ import ToastUI
 struct FeedsView: View {
 
     @ObservedViewModel private var viewModel: FeedsViewModelProtocol = Resolver.resolve()
+    @ObservedViewModel private var sideMenuActionsViewModel: SideMenuActionsViewModelProtocol = Resolver.resolve()
+
+    @EnvironmentObject private var userSessionViewModel: UserSessionViewModel
 
     @State private var isFirstLoad: Bool = true
     @State private var isShowingCreateArticleScreen = false
     @State private var selectedTabIndex: Int = 0
-
-    // TODO: Implement the logic when to show new article ToolbarItem button in integrate task, default to false
     @State private var isAuthenticated = false
 
     @Binding private var isSideMenuDraggingEnabled: Bool
@@ -43,8 +44,14 @@ struct FeedsView: View {
             .onDisappear { isSideMenuDraggingEnabled = false }
         }
         .accentColor(.white)
-        .onAppear { viewModel.input.viewOnAppear() }
-        .bind(viewModel.output.isAuthenticated, to: _isAuthenticated)
+        .onAppear {
+            userSessionViewModel.input.getUserSession()
+            viewModel.input.bindData(
+                sideMenuActionsViewModel: sideMenuActionsViewModel,
+                userSessionViewModel: userSessionViewModel
+            )
+        }
+        .bind(userSessionViewModel.output.isAuthenticated, to: _isAuthenticated)
         .fullScreenCover(isPresented: $isShowingCreateArticleScreen) { CreateArticleView() }
     }
 

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsViewModel.swift
@@ -12,8 +12,11 @@ import SwiftUI
 
 protocol FeedsViewModelInput {
 
+    func bindData(
+        sideMenuActionsViewModel: SideMenuActionsViewModelProtocol,
+        userSessionViewModel: UserSessionViewModelProtocol
+    )
     func toggleSideMenu()
-    func viewOnAppear()
 }
 
 protocol FeedsViewModelOutput {
@@ -21,7 +24,6 @@ protocol FeedsViewModelOutput {
     var yourFeedsViewModel: FeedsTabViewModelProtocol { get }
     var globalFeedsViewModel: FeedsTabViewModelProtocol { get }
     var didToggleSideMenu: Signal<Void> { get }
-    var isAuthenticated: Driver<Bool> { get }
 }
 
 protocol FeedsViewModelProtocol: ObservableViewModel {
@@ -42,12 +44,9 @@ final class FeedsViewModel: ObservableObject, FeedsViewModelProtocol {
     private let getCurrentUserSessionTrigger = PublishRelay<Void>()
 
     @PublishRelayProperty var didToggleSideMenu: Signal<Void>
-    @BehaviorRelayProperty(false) var isAuthenticated: Driver<Bool>
 
     let yourFeedsViewModel: FeedsTabViewModelProtocol
     let globalFeedsViewModel: FeedsTabViewModelProtocol
-
-    @Injected private var getCurrentSessionUseCase: GetCurrentSessionUseCaseProtocol
 
     init() {
         yourFeedsViewModel = Resolver.resolve(
@@ -58,42 +57,33 @@ final class FeedsViewModel: ObservableObject, FeedsViewModelProtocol {
             FeedsTabViewModelProtocol.self,
             args: FeedsTabView.TabType.globalFeeds
         )
-
-        getCurrentUserSessionTrigger
-            .withUnretained(self)
-            .flatMapLatest { owner, _ in owner.getCurrentUserSessionTriggered(owner: owner) }
-            .subscribe()
-            .disposed(by: disposeBag)
     }
 }
 
 extension FeedsViewModel: FeedsViewModelInput {
 
-    func toggleSideMenu() {
-        $didToggleSideMenu.accept(())
+    func bindData(
+        sideMenuActionsViewModel: SideMenuActionsViewModelProtocol,
+        userSessionViewModel: UserSessionViewModelProtocol
+    ) {
+        sideMenuActionsViewModel.output.didLogin.asObservable()
+            .subscribe(
+                with: self,
+                onNext: { _, _ in userSessionViewModel.input.getUserSession() }
+            )
+            .disposed(by: disposeBag)
+
+        sideMenuActionsViewModel.output.didLogout.asObservable()
+            .subscribe(
+                with: self,
+                onNext: { _, _ in userSessionViewModel.input.getUserSession() }
+            )
+            .disposed(by: disposeBag)
     }
 
-    func viewOnAppear() {
-        getCurrentUserSessionTrigger.accept(())
+    func toggleSideMenu() {
+        $didToggleSideMenu.accept(())
     }
 }
 
 extension FeedsViewModel: FeedsViewModelOutput {}
-
-// MARK: - Private
-
-extension FeedsViewModel {
-
-    private func getCurrentUserSessionTriggered(owner: FeedsViewModel) -> Observable<Void> {
-        getCurrentSessionUseCase
-            .execute()
-            .map { $0 != nil }
-            .do(
-                onSuccess: { owner.$isAuthenticated.accept($0) },
-                onError: { _ in owner.$isAuthenticated.accept(false) }
-            )
-            .asObservable()
-            .mapToVoid()
-            .catchAndReturn(())
-    }
-}

--- a/NimbleMedium/Sources/Presentation/Modules/Shared/UserSessionViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Shared/UserSessionViewModel.swift
@@ -10,16 +10,19 @@ import RxCocoa
 import RxSwift
 import SwiftUI
 
+// sourcery: AutoMockable
 protocol UserSessionViewModelInput {
 
     func getUserSession()
 }
 
+// sourcery: AutoMockable
 protocol UserSessionViewModelOutput {
 
     var isAuthenticated: Driver<Bool> { get }
 }
 
+// sourcery: AutoMockable
 protocol UserSessionViewModelProtocol: ObservableViewModel {
 
     var input: UserSessionViewModelInput { get }

--- a/NimbleMedium/Sources/Presentation/Modules/Shared/UserSessionViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Shared/UserSessionViewModel.swift
@@ -1,0 +1,75 @@
+//
+//  UserSessionViewModel.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 01/11/2021.
+//
+
+import Resolver
+import RxCocoa
+import RxSwift
+import SwiftUI
+
+protocol UserSessionViewModelInput {
+
+    func getUserSession()
+}
+
+protocol UserSessionViewModelOutput {
+
+    var isAuthenticated: Driver<Bool> { get }
+}
+
+protocol UserSessionViewModelProtocol: ObservableViewModel {
+
+    var input: UserSessionViewModelInput { get }
+    var output: UserSessionViewModelOutput { get }
+}
+
+final class UserSessionViewModel: ObservableObject, UserSessionViewModelProtocol {
+
+    var input: UserSessionViewModelInput { self }
+    var output: UserSessionViewModelOutput { self }
+
+    private let disposeBag = DisposeBag()
+    private let getCurrentUserSessionTrigger = PublishRelay<Void>()
+
+    @BehaviorRelayProperty(false) var isAuthenticated: Driver<Bool>
+
+    @Injected private var getCurrentSessionUseCase: GetCurrentSessionUseCaseProtocol
+
+    init() {
+        getCurrentUserSessionTrigger
+            .withUnretained(self)
+            .flatMapLatest { owner, _ in owner.getCurrentUserSessionTriggered(owner: owner) }
+            .subscribe()
+            .disposed(by: disposeBag)
+    }
+}
+
+extension UserSessionViewModel: UserSessionViewModelInput {
+
+    func getUserSession() {
+        getCurrentUserSessionTrigger.accept(())
+    }
+}
+
+extension UserSessionViewModel: UserSessionViewModelOutput {}
+
+// MARK: - Private
+
+extension UserSessionViewModel {
+
+    private func getCurrentUserSessionTriggered(owner: UserSessionViewModel) -> Observable<Void> {
+        getCurrentSessionUseCase
+            .execute()
+            .map { $0 != nil }
+            .do(
+                onSuccess: { owner.$isAuthenticated.accept($0) },
+                onError: { _ in owner.$isAuthenticated.accept(false) }
+            )
+            .asObservable()
+            .mapToVoid()
+            .catchAndReturn(())
+    }
+}

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsView.swift
@@ -17,18 +17,33 @@ struct SideMenuActionsView: View {
     @Injected private var signupViewModel: SignupViewModelProtocol
     @Injected private var homeViewModel: HomeViewModelProtocol
 
+    @EnvironmentObject private var userSessionViewModel: UserSessionViewModel
+
     @State private var isAuthenticated = false
     @State private var isShowingLoginScreen = false
     @State private var isShowingSignupScreen = false
     @State private var isShowingMyProfileScreen = false
     @State private var showLogoutConfirmationAlert = false
 
-    var body: some View {
+    @ViewBuilder var contentsView: some View {
         if isAuthenticated {
             authenticatedMenuOptions
         } else {
             unauthenticatedMenuHeader
         }
+    }
+    
+    var body: some View {
+        contentsView
+            .onAppear {
+                viewModel.input.bindData(
+                    loginViewModel: loginViewModel,
+                    signupViewModel: signupViewModel,
+                    homeViewModel: homeViewModel,
+                    userSessionViewModel: userSessionViewModel
+                )
+            }
+            .bind(userSessionViewModel.output.isAuthenticated, to: _isAuthenticated)
     }
 
     var authenticatedMenuOptions: some View {
@@ -63,7 +78,6 @@ struct SideMenuActionsView: View {
             }
         }
         .bind(viewModel.output.didSelectMyProfileOption, to: _isShowingMyProfileScreen)
-        .bind(viewModel.output.isAuthenticated, to: _isAuthenticated)
     }
 
     var unauthenticatedMenuHeader: some View {
@@ -90,15 +104,6 @@ struct SideMenuActionsView: View {
         }
         .bind(viewModel.output.didSelectLoginOption, to: _isShowingLoginScreen)
         .bind(viewModel.output.didSelectSignupOption, to: _isShowingSignupScreen)
-        .bind(viewModel.output.isAuthenticated, to: _isAuthenticated)
-    }
-
-    init() {
-        viewModel.input.bindData(
-            loginViewModel: loginViewModel,
-            signupViewModel: signupViewModel,
-            homeViewModel: homeViewModel
-        )
     }
 }
 

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsView.swift
@@ -32,7 +32,7 @@ struct SideMenuActionsView: View {
             unauthenticatedMenuHeader
         }
     }
-    
+
     var body: some View {
         contentsView
             .onAppear {

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsView.swift
@@ -25,7 +25,7 @@ struct SideMenuActionsView: View {
     @State private var isShowingMyProfileScreen = false
     @State private var showLogoutConfirmationAlert = false
 
-    @ViewBuilder var contentsView: some View {
+    @ViewBuilder var contentView: some View {
         if isAuthenticated {
             authenticatedMenuOptions
         } else {
@@ -34,7 +34,7 @@ struct SideMenuActionsView: View {
     }
 
     var body: some View {
-        contentsView
+        contentView
             .onAppear {
                 viewModel.input.bindData(
                     loginViewModel: loginViewModel,

--- a/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/SideMenu/SideMenuActions/SideMenuActionsViewModel.swift
@@ -16,7 +16,8 @@ protocol SideMenuActionsViewModelInput {
     func bindData(
         loginViewModel: LoginViewModelProtocol,
         signupViewModel: SignupViewModelProtocol,
-        homeViewModel: HomeViewModelProtocol
+        homeViewModel: HomeViewModelProtocol,
+        userSessionViewModel: UserSessionViewModelProtocol
     )
     func selectLoginOption()
     func selectLogoutOption()
@@ -28,10 +29,10 @@ protocol SideMenuActionsViewModelInput {
 protocol SideMenuActionsViewModelOutput {
 
     var didLogout: Signal<Void> { get }
+    var didLogin: Signal<Void> { get }
     var didSelectLoginOption: Signal<Bool> { get }
     var didSelectMyProfileOption: Signal<Bool> { get }
     var didSelectSignupOption: Signal<Bool> { get }
-    var isAuthenticated: Driver<Bool> { get }
 }
 
 // sourcery: AutoMockable
@@ -49,25 +50,16 @@ final class SideMenuActionsViewModel: ObservableObject, SideMenuActionsViewModel
     var output: SideMenuActionsViewModelOutput { self }
 
     @PublishRelayProperty var didLogout: Signal<Void>
+    @PublishRelayProperty var didLogin: Signal<Void>
     @PublishRelayProperty var didSelectLoginOption: Signal<Bool>
     @PublishRelayProperty var didSelectMyProfileOption: Signal<Bool>
     @PublishRelayProperty var didSelectSignupOption: Signal<Bool>
 
-    @BehaviorRelayProperty(false) var isAuthenticated: Driver<Bool>
-
-    @Injected var getCurrentSessionUseCase: GetCurrentSessionUseCaseProtocol
     @Injected var logoutUseCase: LogoutUseCaseProtocol
 
-    private let getCurrentUserSessionTrigger = PublishRelay<Void>()
     private let logoutTrigger = PublishRelay<Void>()
 
     init() {
-        getCurrentUserSessionTrigger
-            .withUnretained(self)
-            .flatMapLatest { owner, _ in owner.getCurrentUserSessionTriggered(owner: owner) }
-            .subscribe()
-            .disposed(by: disposeBag)
-
         logoutTrigger
             .withUnretained(self)
             .flatMapLatest { owner, _ in owner.logoutTriggered(owner: owner) }
@@ -81,12 +73,20 @@ extension SideMenuActionsViewModel: SideMenuActionsViewModelInput {
     func bindData(
         loginViewModel: LoginViewModelProtocol,
         signupViewModel: SignupViewModelProtocol,
-        homeViewModel: HomeViewModelProtocol
+        homeViewModel: HomeViewModelProtocol,
+        userSessionViewModel: UserSessionViewModelProtocol
     ) {
         loginViewModel.output.didSelectNoAccount.asObservable()
             .subscribe(
                 with: self,
                 onNext: { owner, _ in owner.selectSignupOption() }
+            )
+            .disposed(by: disposeBag)
+
+        loginViewModel.output.didLogin.asObservable()
+            .subscribe(
+                with: self,
+                onNext: { owner, _ in owner.$didLogin.accept(()) }
             )
             .disposed(by: disposeBag)
 
@@ -99,7 +99,7 @@ extension SideMenuActionsViewModel: SideMenuActionsViewModelInput {
 
         homeViewModel.output.isSideMenuOpenDidChange
             .filter { $0 }
-            .emit(with: self) { owner, _ in owner.getCurrentUserSessionTrigger.accept(()) }
+            .emit(with: self) { _, _ in userSessionViewModel.input.getUserSession() }
             .disposed(by: disposeBag)
     }
 
@@ -123,19 +123,6 @@ extension SideMenuActionsViewModel: SideMenuActionsViewModelInput {
 extension SideMenuActionsViewModel: SideMenuActionsViewModelOutput {}
 
 extension SideMenuActionsViewModel {
-
-    private func getCurrentUserSessionTriggered(owner: SideMenuActionsViewModel) -> Observable<Void> {
-        getCurrentSessionUseCase
-            .execute()
-            .map { $0 != nil }
-            .do(
-                onSuccess: { owner.$isAuthenticated.accept($0) },
-                onError: { _ in owner.$isAuthenticated.accept(false) }
-            )
-            .asObservable()
-            .mapToVoid()
-            .catchAndReturn(())
-    }
 
     private func logoutTriggered(owner: SideMenuActionsViewModel) -> Observable<Void> {
         logoutUseCase

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/Feeds/FeedsViewModelSpec.swift
@@ -18,10 +18,18 @@ final class FeedsViewModelSpec: QuickSpec {
 
     @LazyInjected var getCurrentSessionUseCase: GetCurrentSessionUseCaseProtocolMock
 
+    @LazyInjected var sideMenuActionsViewModel: SideMenuActionsViewModelProtocolMock
+
     override func spec() {
+
         var viewModel: FeedsViewModelProtocol!
         var scheduler: TestScheduler!
         var disposeBag: DisposeBag!
+
+        var userSessionViewModel: UserSessionViewModelProtocolMock!
+
+        var sideMenuActionsViewModelOutput: SideMenuActionsViewModelOutputMock!
+        var userSessionViewModelInput: UserSessionViewModelInputMock!
 
         describe("a FeedsViewModel") {
 
@@ -53,9 +61,39 @@ final class FeedsViewModelSpec: QuickSpec {
                 scheduler = TestScheduler(initialClock: 0)
                 disposeBag = DisposeBag()
                 viewModel = FeedsViewModel()
+                userSessionViewModel = UserSessionViewModelProtocolMock()
+
+                sideMenuActionsViewModelOutput = SideMenuActionsViewModelOutputMock()
+                sideMenuActionsViewModelOutput.underlyingDidLogout = .just(())
+                sideMenuActionsViewModelOutput.underlyingDidLogin = .just(())
+                self.sideMenuActionsViewModel.output = sideMenuActionsViewModelOutput
+
+                userSessionViewModelInput = UserSessionViewModelInputMock()
+                userSessionViewModel.input = userSessionViewModelInput
             }
 
-            describe("its toggleSideMenu() call") {
+            describe("its bindData call") {
+
+                beforeEach {
+                    bindData()
+                }
+
+                context("when sideMenuActionsViewModel didLogin emits event") {
+
+                    it("calls userSessionViewModel's input getUserSession") {
+                        expect(userSessionViewModelInput.getUserSessionCalled) == true
+                    }
+                }
+
+                context("when sideMenuActionsViewModel didLogout emits event") {
+
+                    it("calls userSessionViewModel's input getUserSession") {
+                        expect(userSessionViewModelInput.getUserSessionCalled) == true
+                    }
+                }
+            }
+
+            describe("its toggleSideMenu call") {
 
                 beforeEach {
                     scheduler.scheduleAt(5) {
@@ -70,70 +108,11 @@ final class FeedsViewModelSpec: QuickSpec {
                 }
             }
 
-            describe("its viewOnAppear() call") {
-
-                let user = UserDummy()
-
-                beforeEach {
-                    self.getCurrentSessionUseCase.executeReturnValue = .just(user)
-                }
-
-                context("when getCurrentSessionUseCase returns a valid user session") {
-
-                    beforeEach {
-                        self.getCurrentSessionUseCase.executeReturnValue =
-                            .just(user, on: scheduler, at: 50)
-
-                        viewModel.input.viewOnAppear()
-                    }
-
-                    it("returns output with isAuthenticated as true") {
-                        expect(viewModel.output.isAuthenticated)
-                            .events(scheduler: scheduler, disposeBag: disposeBag)
-                            .to(equal([
-                                .next(0, false),
-                                .next(50, true)
-                            ]))
-                    }
-                }
-
-                context("when getCurrentSessionUseCase returns an invalid user session") {
-
-                    beforeEach {
-                        self.getCurrentSessionUseCase.executeReturnValue =
-                            .just(nil, on: scheduler, at: 50)
-
-                        viewModel.input.viewOnAppear()
-                    }
-
-                    it("returns output with isAuthenticated as false") {
-                        expect(viewModel.output.isAuthenticated)
-                            .events(scheduler: scheduler, disposeBag: disposeBag)
-                            .to(equal([
-                                .next(0, false),
-                                .next(50, false)
-                            ]))
-                    }
-                }
-
-                context("when getCurrentSessionUseCase returns an error getting the user session") {
-
-                    beforeEach {
-                        self.getCurrentSessionUseCase.executeReturnValue =
-                            .error(TestError.mock, on: scheduler, at: 50)
-
-                        viewModel.input.viewOnAppear()
-                    }
-
-                    it("returns output with isAuthenticated as false") {
-                        expect(viewModel.output.isAuthenticated)
-                            .events(scheduler: scheduler, disposeBag: disposeBag)
-                            .to(equal([
-                                .next(0, false),
-                                .next(50, false)
-                            ]))
-                    }
-                }
+            func bindData() {
+                viewModel.input.bindData(
+                    sideMenuActionsViewModel: sideMenuActionsViewModel,
+                    userSessionViewModel: userSessionViewModel
+                )
             }
         }
     }

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/Shared/UserSessionViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/Shared/UserSessionViewModelSpec.swift
@@ -1,0 +1,94 @@
+//
+//  UserSessionViewModelSpec.swift
+//  NimbleMediumTests
+//
+//  Created by Minh Pham on 01/11/2021.
+//
+
+import Nimble
+import Quick
+import Resolver
+import RxNimble
+import RxSwift
+import RxTest
+
+@testable import NimbleMedium
+
+final class UserSessionViewModelSpec: QuickSpec {
+
+    @LazyInjected var getCurrentSessionUseCase: GetCurrentSessionUseCaseProtocolMock
+
+    override func spec() {
+        var viewModel: UserSessionViewModelProtocol!
+        var scheduler: TestScheduler!
+        var disposeBag: DisposeBag!
+
+        describe("a UserSessionViewModel") {
+
+            beforeEach {
+                Resolver.registerMockServices()
+                scheduler = TestScheduler(initialClock: 0)
+                disposeBag = DisposeBag()
+                viewModel = UserSessionViewModel()
+            }
+
+            describe("its getUserSession call") {
+
+                context("when getCurrentSessionUseCase returns a valid user session") {
+
+                    let user = UserDummy()
+
+                    beforeEach {
+                        self.getCurrentSessionUseCase.executeReturnValue =
+                            .just(user, on: scheduler, at: 50)
+                        viewModel.input.getUserSession()
+                    }
+
+                    it("returns output with isAuthenticated as true") {
+                        expect(viewModel.output.isAuthenticated)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .to(equal([
+                                .next(0, false),
+                                .next(50, true)
+                            ]))
+                    }
+                }
+
+                context("when getCurrentSessionUseCase returns an invalid user session") {
+
+                    beforeEach {
+                        self.getCurrentSessionUseCase.executeReturnValue =
+                            .just(nil, on: scheduler, at: 50)
+                        viewModel.input.getUserSession()
+                    }
+
+                    it("returns output with isAuthenticated as false") {
+                        expect(viewModel.output.isAuthenticated)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .to(equal([
+                                .next(0, false),
+                                .next(50, false)
+                            ]))
+                    }
+                }
+
+                context("when getCurrentSessionUseCase returns an error getting the user session") {
+                    beforeEach {
+                        self.getCurrentSessionUseCase.executeReturnValue =
+                            .error(TestError.mock, on: scheduler, at: 50)
+                        viewModel.input.getUserSession()
+                    }
+
+                    it("returns output with isAuthenticated as false") {
+                        expect(viewModel.output.isAuthenticated)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .to(equal([
+                                .next(0, false),
+                                .next(50, false)
+                            ]))
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolved #208 

## What happened

The Home screen won't update tabs when a user login/logout

## Insight

- When login: Home screen shows up 2 tabs: Your Feeds & Global Feeds
- When logout: Home screen only shows the content of Global Feeds tab
- Introduce a shared viewModel: `UserSessionViewModel` for handling the shared session.
- Update unit tests

## Proof Of Work

https://user-images.githubusercontent.com/70877098/139646083-dd7a6a52-446d-4904-b409-c50218f366cd.MP4

All tests are passed:

![Screen Shot 2021-11-01 at 15 47 47](https://user-images.githubusercontent.com/70877098/139646218-60f08d1d-45d3-4ab3-a5ce-dab9df51b37e.png)

