### PR TITLE
[#98] As a user, I can edit my article from the article details screen

### DIFF
--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
@@ -114,9 +114,7 @@ struct ArticleDetailView: View {
                     label: { Image(systemName: SystemImageName.minusSquare.rawValue) }
                 )
                 Button(
-                    action: {
-                        isEditArticlePresenting = true
-                    },
+                    action: { isEditArticlePresenting = true },
                     label: { Image(systemName: SystemImageName.squareAndPencil.rawValue) }
                 )
             }

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
@@ -20,6 +20,7 @@ struct ArticleDetailView: View {
     @State private var isLoadingToastPresented = false
     @State private var isFetchArticleDetailFailed = false
     @State private var isArticleAuthor = false
+    @State private var isEditArticlePresenting = false
 
     // swiftlint:disable identifier_name
     @State private var isDeleteArticleConfirmationAlertPresented = false
@@ -87,6 +88,7 @@ struct ArticleDetailView: View {
             ToastView(String.empty) {}
                 .toastViewStyle(IndefiniteProgressToastViewStyle())
         }
+        .fullScreenCover(isPresented: $isEditArticlePresenting) { EditArticleView(slug: slug) }
     }
 
     var comments: some View {
@@ -113,7 +115,7 @@ struct ArticleDetailView: View {
                 )
                 Button(
                     action: {
-                        // TODO: Show Edit Article screen
+                        isEditArticlePresenting = true
                     },
                     label: { Image(systemName: SystemImageName.squareAndPencil.rawValue) }
                 )

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
@@ -20,7 +20,7 @@ struct ArticleDetailView: View {
     @State private var isLoadingToastPresented = false
     @State private var isFetchArticleDetailFailed = false
     @State private var isArticleAuthor = false
-    @State private var isEditArticlePresenting = false
+    @State private var isEditArticlePresented = false
 
     // swiftlint:disable identifier_name
     @State private var isDeleteArticleConfirmationAlertPresented = false
@@ -88,7 +88,7 @@ struct ArticleDetailView: View {
             ToastView(String.empty) {}
                 .toastViewStyle(IndefiniteProgressToastViewStyle())
         }
-        .fullScreenCover(isPresented: $isEditArticlePresenting) { EditArticleView(slug: slug) }
+        .fullScreenCover(isPresented: $isEditArticlePresented) { EditArticleView(slug: slug) }
     }
 
     var comments: some View {
@@ -114,7 +114,7 @@ struct ArticleDetailView: View {
                     label: { Image(systemName: SystemImageName.minusSquare.rawValue) }
                 )
                 Button(
-                    action: { isEditArticlePresenting = true },
+                    action: { isEditArticlePresented = true },
                     label: { Image(systemName: SystemImageName.squareAndPencil.rawValue) }
                 )
             }


### PR DESCRIPTION
Resolved #98 

## What happened

Integrate go to Edit Article screen

## Insight

- [x] When the users open their own article and enter the `Article Details` screen, show the edit article button, otherwise hide it.
- [x] When the users tap on the edit article button in the top right corner of the article header section, navigate to the `Update Article` screen.
- [x] Once in the `Update Article` screen, the users can tap on the `Back` button to go back to the previous screen.


## Proof Of Work


https://user-images.githubusercontent.com/17875522/139804364-afb57a16-94b9-4090-bd72-d164de1b277b.mov


