### PR TITLE
[#99] As a user, I can edit my own article

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -212,6 +212,9 @@
 		2DC224E62702BB4C008382E3 /* GetFavouritedArticlesUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC224E52702BB4C008382E3 /* GetFavouritedArticlesUseCaseSpec.swift */; };
 		2DC824BC271FF2BD0024CFEF /* GetCurrentUserFollowingArticlesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC824BB271FF2BD0024CFEF /* GetCurrentUserFollowingArticlesUseCase.swift */; };
 		2DC824BE271FF6890024CFEF /* GetCurrentUserFollowingArticlesUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC824BD271FF6890024CFEF /* GetCurrentUserFollowingArticlesUseCaseSpec.swift */; };
+		2DD1C4DF27311137006C7D21 /* EditArticleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD1C4DE27311137006C7D21 /* EditArticleViewModel.swift */; };
+		2DD1C4E127311354006C7D21 /* EditArticleView+UIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD1C4E027311354006C7D21 /* EditArticleView+UIModel.swift */; };
+		2DD1C4E4273118A8006C7D21 /* EditArticleViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD1C4E3273118A8006C7D21 /* EditArticleViewModelSpec.swift */; };
 		2DD4805726D73C67005225CF /* ObservableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD4805526D73C67005225CF /* ObservableViewModel.swift */; };
 		2DD4805826D73C67005225CF /* ObservedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD4805626D73C67005225CF /* ObservedViewModel.swift */; };
 		2DDAD3A026D37E02007F845A /* App+NetworkLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDAD39F26D37E02007F845A /* App+NetworkLogger.swift */; };
@@ -468,6 +471,9 @@
 		2DC224E52702BB4C008382E3 /* GetFavouritedArticlesUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFavouritedArticlesUseCaseSpec.swift; sourceTree = "<group>"; };
 		2DC824BB271FF2BD0024CFEF /* GetCurrentUserFollowingArticlesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentUserFollowingArticlesUseCase.swift; sourceTree = "<group>"; };
 		2DC824BD271FF6890024CFEF /* GetCurrentUserFollowingArticlesUseCaseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetCurrentUserFollowingArticlesUseCaseSpec.swift; sourceTree = "<group>"; };
+		2DD1C4DE27311137006C7D21 /* EditArticleViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditArticleViewModel.swift; sourceTree = "<group>"; };
+		2DD1C4E027311354006C7D21 /* EditArticleView+UIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditArticleView+UIModel.swift"; sourceTree = "<group>"; };
+		2DD1C4E3273118A8006C7D21 /* EditArticleViewModelSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditArticleViewModelSpec.swift; sourceTree = "<group>"; };
 		2DD4805526D73C67005225CF /* ObservableViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservableViewModel.swift; sourceTree = "<group>"; };
 		2DD4805626D73C67005225CF /* ObservedViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservedViewModel.swift; sourceTree = "<group>"; };
 		2DDAD39F26D37E02007F845A /* App+NetworkLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App+NetworkLogger.swift"; sourceTree = "<group>"; };
@@ -667,6 +673,8 @@
 			isa = PBXGroup;
 			children = (
 				2442FDD0272A65B5007AED6A /* EditArticleView.swift */,
+				2DD1C4E027311354006C7D21 /* EditArticleView+UIModel.swift */,
+				2DD1C4DE27311137006C7D21 /* EditArticleViewModel.swift */,
 			);
 			path = EditArticle;
 			sourceTree = "<group>";
@@ -1429,6 +1437,7 @@
 				24773121272FDFF000F82D63 /* Shared */,
 				2D29A70B26F44415001EA24F /* ArticleComments */,
 				2DB31D4F26F1960B007254B9 /* ArticleDetail */,
+				2DD1C4E2273118A8006C7D21 /* EditArticle */,
 				244137CC271E7C9000A1542D /* CreateArticle */,
 				241D3531271695B2007F6BA9 /* EditProfile */,
 				2D79A8FA26EF4A70007B81D1 /* Feeds */,
@@ -1788,6 +1797,15 @@
 			);
 			path = SideMenu;
 			sourceTree = "<group>";
+		};
+		2DD1C4E2273118A8006C7D21 /* EditArticle */ = {
+			isa = PBXGroup;
+			children = (
+				2DD1C4E3273118A8006C7D21 /* EditArticleViewModelSpec.swift */,
+			);
+			name = EditArticle;
+			path = NimbleMediumTests/Sources/Specs/Presentation/Modules/EditArticle;
+			sourceTree = SOURCE_ROOT;
 		};
 		2DD4805426D73C67005225CF /* Combine */ = {
 			isa = PBXGroup;
@@ -2389,6 +2407,7 @@
 				2D031D5526EB1093009A5158 /* View+Bind.swift in Sources */,
 				2D469D3F2704430A00B36AD6 /* AvatarView.swift in Sources */,
 				244137C9271E755700A1542D /* CreateArticleViewModel.swift in Sources */,
+				2DD1C4DF27311137006C7D21 /* EditArticleViewModel.swift in Sources */,
 				24C9393926D89FA300547800 /* AppTextField.swift in Sources */,
 				2D882EDE26F1CCA400DB6560 /* GetArticleCommentsUseCase.swift in Sources */,
 				24F3D7B126DCE8DA00DE2420 /* UserSessionRepository.swift in Sources */,
@@ -2421,6 +2440,7 @@
 				244E0FF527152DA000C01139 /* EditProfileView.swift in Sources */,
 				2D979C30270302650084A3F8 /* GetCreatedArticlesUseCase.swift in Sources */,
 				2DEF1F9426E6029200EB93CC /* DecodableArticle.swift in Sources */,
+				2DD1C4E127311354006C7D21 /* EditArticleView+UIModel.swift in Sources */,
 				2DB31D4E26F18EAB007254B9 /* ArticleDetailViewModel.swift in Sources */,
 				2D17E4F426F07ABA001D3F90 /* View+If.swift in Sources */,
 				241D352C27167C9B007F6BA9 /* EditProfileViewModel.swift in Sources */,
@@ -2471,6 +2491,7 @@
 				2419F8622729325C00511D0F /* ToggleArticleFavoriteStatusUseCaseSpec.swift in Sources */,
 				246B387926F8A7D7003173FD /* SideMenuHeaderViewModelSpec.swift in Sources */,
 				24F3D7BE26DE041F00DE2420 /* LoginViewModelSpec.swift in Sources */,
+				2DD1C4E4273118A8006C7D21 /* EditArticleViewModelSpec.swift in Sources */,
 				2D882EE626F1CF4600DB6560 /* GetArticleCommentsUseCaseSpec.swift in Sources */,
 				24D717F8271D3394009B589C /* CreateArticleUseCaseSpec.swift in Sources */,
 				2D4BB30626FC77B2005FED5F /* ArticleCommentRowViewModelSpec.swift in Sources */,

--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -177,8 +177,9 @@ extension Resolver: ResolverRegistering {
         register { _, args in
             UserProfileFavouritedArticlesTabViewModel(username: args.get())
         }.implements(UserProfileFavouritedArticlesTabViewModelProtocol.self)
-        register { _, args in
+        register(EditArticleViewModelProtocol.self) { _, args in
             EditArticleViewModel(slug: args.get())
-        }.implements(EditArticleViewModelProtocol.self)
+        }
+        .scope(.shared)
     }
 }

--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -177,5 +177,8 @@ extension Resolver: ResolverRegistering {
         register { _, args in
             UserProfileFavouritedArticlesTabViewModel(username: args.get())
         }.implements(UserProfileFavouritedArticlesTabViewModelProtocol.self)
+        register { _, args in
+            EditArticleViewModel(slug: args.get())
+        }.implements(EditArticleViewModelProtocol.self)
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
@@ -14,6 +14,7 @@ import ToastUI
 struct ArticleDetailView: View {
 
     @ObservedViewModel private var viewModel: ArticleDetailViewModelProtocol
+    let editArticleViewModel: EditArticleViewModelProtocol
 
     @State private var uiModel: UIModel?
     @State private var isErrorToastPresented = false
@@ -88,7 +89,7 @@ struct ArticleDetailView: View {
             ToastView(String.empty) {}
                 .toastViewStyle(IndefiniteProgressToastViewStyle())
         }
-        .fullScreenCover(isPresented: $isEditArticlePresented) { EditArticleView(slug: slug) }
+        .fullScreenCover(isPresented: $isEditArticlePresented) { EditArticleView() }
     }
 
     var comments: some View {
@@ -124,10 +125,16 @@ struct ArticleDetailView: View {
     init(slug: String) {
         self.slug = slug
 
+        editArticleViewModel = Resolver.resolve(
+            EditArticleViewModelProtocol.self,
+            args: slug
+        )
+
         viewModel = Resolver.resolve(
             ArticleDetailViewModelProtocol.self,
             args: slug
         )
+        viewModel.input.bindData(editArticleViewModel: editArticleViewModel)
     }
 
     func articleDetail(uiModel: UIModel) -> some View {

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailViewModel.swift
@@ -20,6 +20,7 @@ protocol ArticleDetailViewModelInput {
 
 protocol ArticleDetailViewModelOutput {
 
+    var editArticleViewModel: EditArticleViewModelProtocol { get }
     var id: String { get }
     var didFailToFetchArticleDetail: Signal<Void> { get }
     var didFailToToggleFollow: Signal<Void> { get }
@@ -54,6 +55,7 @@ final class ArticleDetailViewModel: ObservableObject, ArticleDetailViewModelProt
     private var article: Article?
     private var articleIsFavourite: Bool = false
 
+    let editArticleViewModel: EditArticleViewModelProtocol
     @PublishRelayProperty var didFetch: Signal<Void>
     @PublishRelayProperty var didFailToFetchArticleDetail: Signal<Void>
     @PublishRelayProperty var didFailToToggleFollow: Signal<Void>
@@ -70,6 +72,13 @@ final class ArticleDetailViewModel: ObservableObject, ArticleDetailViewModelProt
 
     init(id: String) {
         self.id = id
+
+        editArticleViewModel = Resolver.resolve(EditArticleViewModelProtocol.self, args: id)
+        editArticleViewModel.output.didUpdateArticle
+            .emit(with: self) { owner, _ in
+                owner.fetchArticleDetail()
+            }
+            .disposed(by: disposeBag)
 
         fetchArticleDetailTrigger
             .withUnretained(self)

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailViewModel.swift
@@ -12,6 +12,7 @@ import RxSwift
 
 protocol ArticleDetailViewModelInput {
 
+    func bindData(editArticleViewModel: EditArticleViewModelProtocol)
     func fetchArticleDetail()
     func toggleFollowUser()
     func toggleFavouriteArticle()
@@ -20,7 +21,6 @@ protocol ArticleDetailViewModelInput {
 
 protocol ArticleDetailViewModelOutput {
 
-    var editArticleViewModel: EditArticleViewModelProtocol { get }
     var id: String { get }
     var didFailToFetchArticleDetail: Signal<Void> { get }
     var didFailToToggleFollow: Signal<Void> { get }
@@ -55,7 +55,6 @@ final class ArticleDetailViewModel: ObservableObject, ArticleDetailViewModelProt
     private var article: Article?
     private var articleIsFavourite: Bool = false
 
-    let editArticleViewModel: EditArticleViewModelProtocol
     @PublishRelayProperty var didFetch: Signal<Void>
     @PublishRelayProperty var didFailToFetchArticleDetail: Signal<Void>
     @PublishRelayProperty var didFailToToggleFollow: Signal<Void>
@@ -72,13 +71,6 @@ final class ArticleDetailViewModel: ObservableObject, ArticleDetailViewModelProt
 
     init(id: String) {
         self.id = id
-
-        editArticleViewModel = Resolver.resolve(EditArticleViewModelProtocol.self, args: id)
-        editArticleViewModel.output.didUpdateArticle
-            .emit(with: self) { owner, _ in
-                owner.fetchArticleDetail()
-            }
-            .disposed(by: disposeBag)
 
         fetchArticleDetailTrigger
             .withUnretained(self)
@@ -113,6 +105,14 @@ final class ArticleDetailViewModel: ObservableObject, ArticleDetailViewModelProt
 }
 
 extension ArticleDetailViewModel: ArticleDetailViewModelInput {
+
+    func bindData(editArticleViewModel: EditArticleViewModelProtocol) {
+        editArticleViewModel.output.didUpdateArticle
+            .emit(with: self) { owner, _ in
+                owner.fetchArticleDetail()
+            }
+            .disposed(by: disposeBag)
+    }
 
     func fetchArticleDetail() {
         fetchArticleDetailTrigger.accept(())

--- a/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleView+UIModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleView+UIModel.swift
@@ -15,12 +15,5 @@ extension EditArticleView {
         let description: String
         let articleBody: String
         let tagsList: String
-
-        init(article: Article) {
-            title = article.title
-            description = article.description
-            articleBody = article.body
-            tagsList = article.tagList.joined(separator: ",")
-        }
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleView+UIModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleView+UIModel.swift
@@ -1,0 +1,26 @@
+//
+//  EditArticleView+UIModel.swift
+//  NimbleMedium
+//
+//  Created by Mark G on 02/11/2021.
+//
+
+import Foundation
+
+extension EditArticleView {
+
+    struct UIModel: Equatable {
+
+        let title: String
+        let description: String
+        let articleBody: String
+        let tagsList: String
+
+        init(article: Article) {
+            title = article.title
+            description = article.description
+            articleBody = article.body
+            tagsList = article.tagList.joined(separator: ",")
+        }
+    }
+}

--- a/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleView.swift
@@ -110,13 +110,13 @@ struct EditArticleView: View {
         }
     }
 
-    init(viewModel: EditArticleViewModelProtocol) {
-        self.viewModel = viewModel
+    init() {
+        viewModel = Resolver.resolve()
     }
 }
 
 #if DEBUG
     struct EditArticleView_Previews: PreviewProvider {
-        static var previews: some View { EditArticleView(viewModel: Resolver.resolve()) }
+        static var previews: some View { EditArticleView() }
     }
 #endif

--- a/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleView.swift
@@ -13,7 +13,7 @@ struct EditArticleView: View {
 
     @Environment(\.presentationMode) var presentationMode
 
-    @ObservedViewModel private var viewModel: EditArticleViewModelProtocol
+    @ObservedViewModel private var viewModel: EditArticleViewModelProtocol = Resolver.resolve()
 
     @State private var title = ""
     @State private var description = ""
@@ -108,10 +108,6 @@ struct EditArticleView: View {
             }
             .padding()
         }
-    }
-
-    init() {
-        viewModel = Resolver.resolve()
     }
 }
 

--- a/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleView.swift
@@ -13,12 +13,16 @@ struct EditArticleView: View {
 
     @Environment(\.presentationMode) var presentationMode
 
+    @ObservedViewModel private var viewModel: EditArticleViewModelProtocol
+
     @State private var title = ""
     @State private var description = ""
     @State private var articleBody = ""
     @State private var tagsList = ""
-
-    private let slug: String
+    @State private var isFetchArticleDetailFailed = false
+    @State private var isFetchArticleDetailSuccess = false
+    @State private var isLoadingToastPresented = false
+    @State private var isErrorToastPresented = false
 
     var body: some View {
         NavigationView {
@@ -29,6 +33,35 @@ struct EditArticleView: View {
                 .toolbar { navigationBarLeadingContent }
         }
         .accentColor(.white)
+        .toast(isPresented: $isErrorToastPresented, dismissAfter: 3.0) {
+            ToastView(Localizable.errorGeneric()) {} background: {
+                Color.clear
+            }
+        }
+        .onAppear { viewModel.input.fetchArticleDetail() }
+        .onReceive(viewModel.output.didFailToUpdateArticle) { _ in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                isErrorToastPresented = true
+            }
+        }
+        .onReceive(viewModel.output.didUpdateArticle) { _ in presentationMode.wrappedValue.dismiss() }
+        .onReceive(viewModel.output.didFailToFetchArticleDetail) { _ in
+            isErrorToastPresented = true
+            isFetchArticleDetailFailed = true
+        }
+        .bind(viewModel.output.isLoading, to: _isLoadingToastPresented)
+        .onReceive(viewModel.output.uiModel) {
+            guard let uiModel = $0 else { return }
+            isFetchArticleDetailSuccess = true
+            title = uiModel.title
+            description = uiModel.description
+            articleBody = uiModel.articleBody
+            tagsList = uiModel.tagsList
+        }
+        .toast(isPresented: $isLoadingToastPresented) {
+            ToastView(String.empty) {}
+                .toastViewStyle(IndefiniteProgressToastViewStyle())
+        }
     }
 
     var navigationBarLeadingContent: some ToolbarContent {
@@ -41,6 +74,16 @@ struct EditArticleView: View {
     }
 
     var contentView: some View {
+        Group {
+            if isFetchArticleDetailSuccess { form } else {
+                if isFetchArticleDetailFailed {
+                    Text(Localizable.articleDetailFetchFailureMessage())
+                } else { ProgressView() }
+            }
+        }
+    }
+
+    var form: some View {
         ScrollView {
             VStack(spacing: 15.0) {
                 ArticleInputFields(fields: [
@@ -54,20 +97,26 @@ struct EditArticleView: View {
                     .textField(placeholder: Localizable.editArticleTextFieldTagsListPlaceholder(), text: $tagsList)
                 ])
                 AppMainButton(title: Localizable.actionUpdateText()) {
-                    // TODO: Implement in integrate task
+                    viewModel.input.didTapUpdateButton(
+                        title: title,
+                        description: description,
+                        body: articleBody,
+                        tagsList: tagsList
+                    )
                 }
+                .disabled(title.isEmpty && description.isEmpty && articleBody.isEmpty && tagsList.isEmpty)
             }
             .padding()
         }
     }
 
-    init(slug: String) {
-        self.slug = slug
+    init(viewModel: EditArticleViewModelProtocol) {
+        self.viewModel = viewModel
     }
 }
 
 #if DEBUG
     struct EditArticleView_Previews: PreviewProvider {
-        static var previews: some View { EditArticleView(slug: "") }
+        static var previews: some View { EditArticleView(viewModel: Resolver.resolve()) }
     }
 #endif

--- a/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleViewModel.swift
@@ -112,7 +112,7 @@ extension EditArticleViewModel {
                             description: $0.description,
                             articleBody: $0.body,
                             tagsList: $0.tagList.joined(separator: ",")
-                         )
+                        )
                     )
                 },
                 onError: { _ in owner.$didFailToFetchArticleDetail.accept(()) }

--- a/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleViewModel.swift
@@ -106,7 +106,14 @@ extension EditArticleViewModel {
             .execute(slug: slug)
             .do(
                 onSuccess: {
-                    owner.$uiModel.accept(.init(article: $0))
+                    owner.$uiModel.accept(
+                        .init(
+                            title: $0.title,
+                            description: $0.description,
+                            articleBody: $0.body,
+                            tagsList: $0.tagList.joined(separator: ",")
+                         )
+                    )
                 },
                 onError: { _ in owner.$didFailToFetchArticleDetail.accept(()) }
             )

--- a/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleViewModel.swift
@@ -1,0 +1,143 @@
+//
+//  EditArticleViewModel.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 19/10/2021.
+//
+
+import Combine
+import Resolver
+import RxCocoa
+import RxSwift
+
+// sourcery: AutoMockable
+protocol EditArticleViewModelInput {
+
+    func didTapUpdateButton(
+        title: String,
+        description: String,
+        body: String,
+        tagsList: String
+    )
+
+    func fetchArticleDetail()
+}
+
+protocol EditArticleViewModelOutput {
+
+    var uiModel: Driver<EditArticleView.UIModel?> { get }
+    var didFailToFetchArticleDetail: Signal<Void> { get }
+    var didUpdateArticle: Signal<Void> { get }
+    var didFailToUpdateArticle: Signal<Void> { get }
+    var isLoading: Driver<Bool> { get }
+}
+
+protocol EditArticleViewModelProtocol: ObservableViewModel {
+
+    var input: EditArticleViewModelInput { get }
+    var output: EditArticleViewModelOutput { get }
+}
+
+final class EditArticleViewModel: ObservableObject, EditArticleViewModelProtocol {
+
+    typealias UpdateArticleParams = (
+        title: String, description: String, body: String, tagsList: [String]
+    )
+
+    private let disposeBag = DisposeBag()
+    private let slug: String
+
+    var input: EditArticleViewModelInput { self }
+    var output: EditArticleViewModelOutput { self }
+
+    @PublishRelayProperty var didUpdateArticle: Signal<Void>
+    @PublishRelayProperty var didFailToUpdateArticle: Signal<Void>
+    @PublishRelayProperty var didFailToFetchArticleDetail: Signal<Void>
+
+    @BehaviorRelayProperty(false) var isLoading: Driver<Bool>
+    @BehaviorRelayProperty(nil) var uiModel: Driver<EditArticleView.UIModel?>
+
+    @Injected var updateArticleUseCase: UpdateMyArticleUseCaseProtocol
+    @Injected var getArticleUseCase: GetArticleUseCaseProtocol
+
+    private let updateArticleTrigger = PublishRelay<UpdateArticleParams>()
+    private let fetchArticleDetailTrigger = PublishRelay<Void>()
+
+    init(slug: String) {
+        self.slug = slug
+
+        fetchArticleDetailTrigger
+            .withUnretained(self)
+            .flatMapLatest { $0.0.fetchArticleDetailTriggered(owner: $0.0) }
+            .subscribe()
+            .disposed(by: disposeBag)
+
+        updateArticleTrigger
+            .withUnretained(self)
+            .flatMapLatest { owner, inputs in owner.updateArticleTriggered(owner: owner, inputs: inputs) }
+            .subscribe()
+            .disposed(by: disposeBag)
+    }
+}
+
+extension EditArticleViewModel: EditArticleViewModelInput {
+
+    func didTapUpdateButton(
+        title: String,
+        description: String,
+        body: String,
+        tagsList: String
+    ) {
+        $isLoading.accept(true)
+        updateArticleTrigger.accept((title, description, body, tagsList.toStringsArray()))
+    }
+
+    func fetchArticleDetail() {
+        fetchArticleDetailTrigger.accept(())
+    }
+}
+
+extension EditArticleViewModel: EditArticleViewModelOutput {}
+
+extension EditArticleViewModel {
+
+    private func fetchArticleDetailTriggered(owner: EditArticleViewModel) -> Observable<Void> {
+        getArticleUseCase
+            .execute(slug: slug)
+            .do(
+                onSuccess: {
+                    owner.$uiModel.accept(.init(article: $0))
+                },
+                onError: { _ in owner.$didFailToFetchArticleDetail.accept(()) }
+            )
+            .asObservable()
+            .mapToVoid()
+            .catchAndReturn(())
+    }
+
+    private func updateArticleTriggered(owner: EditArticleViewModel, inputs: UpdateArticleParams) -> Observable<Void> {
+        updateArticleUseCase
+            .execute(
+                slug: owner.slug,
+                params: .init(
+                    title: inputs.title,
+                    description: inputs.description,
+                    body: inputs.body,
+                    tagList: inputs.tagsList
+                )
+            )
+            .do(
+                onError: { _ in
+                    owner.$isLoading.accept(false)
+                    owner.$didFailToUpdateArticle.accept(())
+                },
+                onCompleted: {
+                    owner.$isLoading.accept(false)
+                    owner.$didUpdateArticle.accept(())
+                }
+            )
+            .asObservable()
+            .mapToVoid()
+            .catchAndReturn(())
+    }
+}

--- a/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsTab/FeedsTabView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Feeds/FeedsTab/FeedsTabView.swift
@@ -116,12 +116,16 @@ extension FeedsTabView {
         }
 
         var articleDetailNavigationLink: some View {
-            NavigationLink(
-                destination: ArticleDetailView(slug: activeDetailID),
-                isActive: $isShowingFeedDetail,
-                label: { EmptyView() }
-            )
-            .hidden()
+            Group {
+                if !activeDetailID.isEmpty {
+                    NavigationLink(
+                        destination: ArticleDetailView(slug: activeDetailID),
+                        isActive: $isShowingFeedDetail,
+                        label: { EmptyView() }
+                    )
+                    .hidden()
+                } else { EmptyView() }
+            }
         }
 
         static func == (lhs: FeedsTabView.FeedList, rhs: FeedsTabView.FeedList) -> Bool {

--- a/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
+++ b/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
@@ -61,6 +61,8 @@ extension Resolver {
             .implements(DeleteMyArticleUseCaseProtocol.self)
         Resolver.mock.register { ToggleArticleFavoriteStatusUseCaseProtocolMock() }
             .implements(ToggleArticleFavoriteStatusUseCaseProtocol.self)
+        Resolver.mock.register { UpdateMyArticleUseCaseProtocolMock() }
+            .implements(UpdateMyArticleUseCaseProtocol.self)
     }
 
     private static func registerViewModels() {

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/EditArticle/EditArticleViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/EditArticle/EditArticleViewModelSpec.swift
@@ -1,0 +1,147 @@
+//
+//  EditArticleViewModelSpec.swift
+//  NimbleMediumTests
+//
+//  Created by Minh Pham on 19/10/2021.
+//
+
+import Nimble
+import Quick
+import Resolver
+import RxNimble
+import RxSwift
+import RxTest
+
+@testable import NimbleMedium
+
+final class EditArticleViewModelSpec: QuickSpec {
+
+    @LazyInjected var updateArticleUseCase: UpdateMyArticleUseCaseProtocolMock
+    @LazyInjected var getArticleUseCase: GetArticleUseCaseProtocolMock
+
+    override func spec() {
+        var viewModel: EditArticleViewModelProtocol!
+        var scheduler: TestScheduler!
+        var disposeBag: DisposeBag!
+
+        describe("a EditArticleViewModel") {
+
+            beforeEach {
+                Resolver.registerMockServices()
+                scheduler = TestScheduler(initialClock: 0)
+                disposeBag = DisposeBag()
+                viewModel = EditArticleViewModel(slug: "slug")
+            }
+
+            describe("its fetchArticle() call") {
+
+                context("when GetArticleUseCase return success") {
+                    let inputArticle = APIArticleResponse.dummy.article
+
+                    beforeEach {
+                        self.getArticleUseCase.executeSlugReturnValue = .just(inputArticle, on: scheduler, at: 10)
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.fetchArticleDetail()
+                        }
+                    }
+
+                    it("returns output uiModel with correct value") {
+                        expect(viewModel.output.uiModel)
+                            .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                                .next(0, nil),
+                                .next(10, .init(article: inputArticle))
+                            ]
+                    }
+                }
+
+                context("when GetArticleUseCase return failure") {
+
+                    beforeEach {
+                        self.getArticleUseCase.executeSlugReturnValue = .error(TestError.mock, on: scheduler, at: 10)
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.fetchArticleDetail()
+                        }
+                    }
+
+                    it("returns output didFailToFetchArticleDetail with signal") {
+                        expect(viewModel.output.didFailToFetchArticleDetail)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .notTo(beEmpty())
+                    }
+                }
+            }
+
+            describe("its didTapUpdateButton() call") {
+
+                let inputArticle = APIArticleResponse.dummy.article
+
+                context("when updateArticleUseCase return success") {
+
+                    beforeEach {
+                        self.getArticleUseCase.executeSlugReturnValue = .just(inputArticle)
+                        self.updateArticleUseCase.executeSlugParamsReturnValue = .empty(on: scheduler, at: 10)
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.didTapUpdateButton(
+                                title: "",
+                                description: "",
+                                body: "",
+                                tagsList: ""
+                            )
+                        }
+                    }
+
+                    it("returns output with isLoading as true then false accordingly") {
+                        expect(viewModel.output.isLoading)
+                            .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                                .next(0, false), // Initial state
+                                .next(5, true), // Start loading
+                                .next(10, false) // Loading complete
+                            ]
+                    }
+
+                    it("returns output with didUpdateArticle event") {
+                        expect(viewModel.output.didUpdateArticle)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .notTo(beEmpty())
+                    }
+                }
+
+                context("when updateArticleUseCase return failure") {
+
+                    beforeEach {
+                        self.getArticleUseCase.executeSlugReturnValue = .just(inputArticle)
+                        self.updateArticleUseCase.executeSlugParamsReturnValue =
+                            .error(TestError.mock, on: scheduler, at: 10)
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.didTapUpdateButton(
+                                title: "",
+                                description: "",
+                                body: "",
+                                tagsList: ""
+                            )
+                        }
+                    }
+
+                    it("returns output with isLoading as true then false accordingly") {
+                        expect(viewModel.output.isLoading)
+                            .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                                .next(0, false), // Initial state
+                                .next(5, true), // Start loading
+                                .next(10, false) // Loading complete
+                            ]
+                    }
+
+                    it("returns output didFailToUpdateArticle with signal") {
+                        expect(viewModel.output.didFailToUpdateArticle)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .notTo(beEmpty())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/EditArticle/EditArticleViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/EditArticle/EditArticleViewModelSpec.swift
@@ -50,7 +50,12 @@ final class EditArticleViewModelSpec: QuickSpec {
                         expect(viewModel.output.uiModel)
                             .events(scheduler: scheduler, disposeBag: disposeBag) == [
                                 .next(0, nil),
-                                .next(10, .init(article: inputArticle))
+                                .next(10, .init(
+                                    title: inputArticle.title,
+                                    description: inputArticle.description,
+                                    articleBody: inputArticle.body,
+                                    tagsList: inputArticle.tagList.joined(separator: ",")
+                                ))
                             ]
                     }
                 }


### PR DESCRIPTION
Resolved #99

## What happened

Integrate Edit Article screen

## Insight

- [x] Enable the `Update` button by default.
- [x] When the users update with non-empty values on the text fields, enable the `Update ` button and need to check to disable the button if all the users inputs are empty.
- [x] When the users press the `Update` button, call the API to update their current article and show a native loading indicator in the middle of the screen while doing so.
- [x] When there is an error while updating the article, show a temporary toast message with text: `Something went wrong. Please try again later.` and just dismiss the loading indicator.
- [x] If the update is successful, dismiss the loading indicator and go back to the previous `Article Details` screen with new contents if any.

## Proof Of Work


https://user-images.githubusercontent.com/17875522/139805533-a6a3f46e-5721-4d53-94e3-ed3111b537af.mov


