### PR TITLE
[#100] As a user, I can comment on an article in the comments history screen

### DIFF
--- a/NimbleMedium/Resources/en.lproj/Localizable.strings
+++ b/NimbleMedium/Resources/en.lproj/Localizable.strings
@@ -40,6 +40,7 @@
 
 "error.generic" = "Something went wrong.\nPlease try again later.";
 
+"feedComments.commentTextView.placeholder" = "Write a comment...";
 "feedComments.noComment.message" = "No Comment";
 "feedComments.title" = "Comments History";
 

--- a/NimbleMedium/Sources/Constants/SystemImageName.swift
+++ b/NimbleMedium/Sources/Constants/SystemImageName.swift
@@ -7,6 +7,7 @@
 
 enum SystemImageName: String {
 
+    case arrowshapeTurnUpForwardCircleFill = "arrowshape.turn.up.forward.circle.fill"
     case chevronBackward = "chevron.backward"
     case heartFill = "heart.fill"
     case minusSquare = "minus.square"

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentsView.swift
@@ -17,27 +17,26 @@ struct ArticleCommentsView: View {
     @State private var isErrorToastPresented = false
     @State private var isFetchingArticleComments = true
     @State private var isFetchArticleCommentsFailed = false
+    @State private var commentContent: String = ""
 
     var body: some View {
-        Group {
-            if !isFetchingArticleComments, let viewModels = articleCommentRowViewModels {
-                if !viewModels.isEmpty {
-                    ScrollView(.vertical) {
-                        LazyVStack(alignment: .leading, spacing: 12.0) {
-                            ForEach(viewModels, id: \.output.id) {
-                                ArticleCommentRow(viewModel: $0)
-                            }
-                        }
-                        .padding(.all, 16.0)
-                    }
-                } else {
-                    Text(Localizable.feedCommentsNoCommentMessage())
+        VStack {
+            comments
+            Spacer()
+            HStack {
+                AppTextView(
+                    placeholder: Localizable.feedCommentsCommentTextViewPlaceholder(),
+                    text: $commentContent
+                )
+                Button {
+                    // TODO: Integrate send comment
+                } label: {
+                    Image(systemName: SystemImageName.arrowshapeTurnUpForwardCircleFill.rawValue)
+                        .foregroundColor(.black)
                 }
-            } else {
-                if isFetchArticleCommentsFailed {
-                    Text(Localizable.feedCommentsNoCommentMessage())
-                } else { ProgressView() }
             }
+            .frame(height: 50)
+            .padding(.horizontal, 20.0)
         }
         .toast(isPresented: $isErrorToastPresented, dismissAfter: 3.0) {
             ToastView(Localizable.errorGeneric()) {} background: {
@@ -58,6 +57,30 @@ struct ArticleCommentsView: View {
             articleCommentRowViewModels = $0
         }
         .onAppear { viewModel.input.fetchArticleComments() }
+    }
+
+    var comments: some View {
+        Group {
+            if !isFetchingArticleComments, let viewModels = articleCommentRowViewModels {
+                if !viewModels.isEmpty {
+                    ScrollView(.vertical) {
+                        LazyVStack(alignment: .leading, spacing: 12.0) {
+                            ForEach(viewModels, id: \.output.id) {
+                                ArticleCommentRow(viewModel: $0)
+                            }
+                        }
+                        .padding(.all, 16.0)
+                    }
+                } else {
+                    Text(Localizable.feedCommentsNoCommentMessage())
+                }
+            } else {
+                if isFetchArticleCommentsFailed {
+                    Text(Localizable.feedCommentsNoCommentMessage())
+                } else { ProgressView() }
+            }
+        }
+        .frame(maxHeight: .infinity)
     }
 
     init(id: String) {


### PR DESCRIPTION
Resolved #100 

## What happened

Create comment input UI

## Insight

- [x] On the `Comments History` screen UI layout from #29, add a comment textview static at the bottom with hint text: `Write a comment...` as show in the below design.
- [x] The default textview height is 1 line, make the textview expandable depending on the text input contents.
- [x] Add a post button on the right of the textview as shown in the below design.
- [x] Use the post icon from below resources.

## Proof Of Work

![Screen Shot 2021-11-03 at 11 46 41](https://user-images.githubusercontent.com/17875522/140011263-1b10e739-ee47-4ccf-b548-49917d325776.png)

When the keyboard is up
![Screen Shot 2021-11-05 at 09 32 18](https://user-images.githubusercontent.com/17875522/140448562-4f02b2d2-c9ab-41d9-a264-fb823d138eb9.png)


