### PR TITLE
[#106]  As a user, I can delete my comment on an article in the comments history screen

### DIFF
--- a/NimbleMedium/Sources/Constants/SystemImageName.swift
+++ b/NimbleMedium/Sources/Constants/SystemImageName.swift
@@ -13,5 +13,6 @@ enum SystemImageName: String {
     case minusSquare = "minus.square"
     case plusSquare = "plus.square"
     case squareAndPencil = "square.and.pencil"
+    case trashFill = "trash.fill"
     case xmark
 }

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentRow/ArticleCommentRow.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentRow/ArticleCommentRow.swift
@@ -12,6 +12,8 @@ struct ArticleCommentRow: View {
 
     @ObservedViewModel private var viewModel: ArticleCommentRowViewModelProtocol
 
+    // TODO: Update to correct value in integrate task, default to hide the delete button for now
+    @State var isMyComment: Bool = false
     @State var uiModel: UIModel?
 
     var body: some View {
@@ -54,6 +56,16 @@ struct ArticleCommentRow: View {
                 .foregroundColor(.green)
             Text(uiModel.commentUpdatedAt)
                 .foregroundColor(.gray)
+            if isMyComment {
+                Spacer()
+                Button(
+                    action: {
+                        // TODO: Handle delete comment in integrate task
+                    },
+                    label: { Image(systemName: SystemImageName.trashFill.rawValue) }
+                )
+                .foregroundColor(.black)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.all, 16.0)


### PR DESCRIPTION
Resolved #106

## What happened

When the users login the application successfully, they can delete their own comment from any article in the `Comments History` screen.

## Insight

- [x] Add a delete comment button to the bottom right corner of the comment table view cell created from #29.
- [x] Reuse the delete comment icon from the UI layout task #91.
- [x] Hide the button by default.

## Proof Of Work
<img src="https://user-images.githubusercontent.com/70877098/140035019-177b4b63-a9b2-44de-92e2-6fd0936bf576.png" width="300">

