### PR TITLE
[#104] As a user, I can comment on an article in the comments history screen

### DIFF
--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -146,9 +146,9 @@ extension Resolver: ResolverRegistering {
         register { _, args in
             ArticleCommentRowViewModel(comment: args.get())
         }.implements(ArticleCommentRowViewModelProtocol.self)
-        register { _, args in
+        register(ArticleCommentsViewModelProtocol.self) { _, args in
             ArticleCommentsViewModel(id: args.get())
-        }.implements(ArticleCommentsViewModelProtocol.self)
+        }.scope(.shared)
         register { _, args in
             ArticleDetailViewModel(id: args.get())
         }.implements(ArticleDetailViewModelProtocol.self)

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentsView.swift
@@ -29,7 +29,7 @@ struct ArticleCommentsView: View {
 
     var body: some View {
         VStack {
-            comments
+            commentsView
             if isAuthenticated {
                 Spacer()
                 commentInput
@@ -61,7 +61,7 @@ struct ArticleCommentsView: View {
         .onAppear { viewModel.input.fetchArticleComments() }
     }
 
-    var comments: some View {
+    var commentsView: some View {
         Group {
             if !isFetchingArticleComments, let viewModels = articleCommentRowViewModels {
                 if !viewModels.isEmpty {

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentsView.swift
@@ -22,6 +22,7 @@ struct ArticleCommentsView: View {
     @State private var commentContent: String = ""
     @State private var isCreateCommentEnabled = false
     @State private var isAuthenticated = false
+
     private var isPostCommentButtonEnabled: Bool {
         isCreateCommentEnabled && !commentContent.isEmpty
     }


### PR DESCRIPTION
Resolved #104

## What happened

Integrate create comment

## Insight

- [x] Show the post comment section only when users are logged in successfully, otherwise hide it.
- [x] Disable the `Post` button by default.
- [x] When the users update with non-empty values on the comment textview, enable the `Post` button and need to check to disable the button again if the users input is empty.
- [x] When the users press the `Post` button, call the API to post the comment and disable the comment textview and the `Post` button while doing so.
- [x] When there is an error while posting the comment to the article, show a temporary toast message with text: `Something went wrong. Please try again later.` 
- [x] If the posting comment task is successful, reload the list of comments table view below with latest data to show the newly posted comment.
- [x] Re-enable the comment textview and the `Post` button after the API call completes regardless it is successful or not.

## Proof Of Work


https://user-images.githubusercontent.com/17875522/140251988-2c2d2c14-79b1-4e33-8723-6ea01b2aef28.mov

