### PR TITLE
[#108] As a user, I can delete my comment on an article in the comments history screen

### DIFF
--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -144,7 +144,7 @@ extension Resolver: ResolverRegistering {
 
     private static func registerViewModels() {
         register { _, args in
-            ArticleCommentRowViewModel(comment: args.get())
+            ArticleCommentRowViewModel(args: args.get())
         }.implements(ArticleCommentRowViewModelProtocol.self)
         register(ArticleCommentsViewModelProtocol.self) { _, args in
             ArticleCommentsViewModel(id: args.get())

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentRow/ArticleCommentRow+UIModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentRow/ArticleCommentRow+UIModel.swift
@@ -15,5 +15,6 @@ extension ArticleCommentRow {
         let commentUpdatedAt: String
         let authorName: String
         let authorImage: URL?
+        let isAuthor: Bool
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentRow/ArticleCommentRow.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentRow/ArticleCommentRow.swift
@@ -13,7 +13,6 @@ struct ArticleCommentRow: View {
 
     @ObservedViewModel private var viewModel: ArticleCommentRowViewModelProtocol
 
-    @State private var isAuthor: Bool = false
     @State private var uiModel: UIModel?
     @State private var isLoadingToastPresented = false
     @State private var isErrorToastPresented = false

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentRow/ArticleCommentRowViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentRow/ArticleCommentRowViewModel.swift
@@ -11,13 +11,19 @@ import RxCocoa
 import RxSwift
 
 // sourcery: AutoMockable
-protocol ArticleCommentRowViewModelInput {}
+protocol ArticleCommentRowViewModelInput {
+
+    func deleteComment()
+}
 
 // sourcery: AutoMockable
 protocol ArticleCommentRowViewModelOutput {
 
     var id: Int { get }
-    var uiModel: Driver<ArticleCommentRow.UIModel> { get }
+    var uiModel: Driver<ArticleCommentRow.UIModel?> { get }
+    var didDeleteComment: Signal<Void> { get }
+    var didFailToDeleteComment: Signal<Void> { get }
+    var isLoading: Driver<Bool> { get }
 }
 
 // sourcery: AutoMockable
@@ -27,36 +33,98 @@ protocol ArticleCommentRowViewModelProtocol: ObservableViewModel {
     var output: ArticleCommentRowViewModelOutput { get }
 }
 
+struct ArticleCommentRowViewModelArgs {
+
+    let slug: String
+    let comment: ArticleComment
+}
+
 final class ArticleCommentRowViewModel: ObservableObject, ArticleCommentRowViewModelProtocol {
 
+    @Injected var getCurrentSessionUseCase: GetCurrentSessionUseCaseProtocol
+    @Injected var deleteArticleCommentUseCase: DeleteArticleCommentUseCaseProtocol
+
     private let disposeBag = DisposeBag()
+    private let deleteCommentTrigger = PublishRelay<Void>()
+    private let slug: String
 
     var input: ArticleCommentRowViewModelInput { self }
     var output: ArticleCommentRowViewModelOutput { self }
 
-    let uiModel: Driver<ArticleCommentRow.UIModel>
+    @BehaviorRelayProperty(nil) var uiModel: Driver<ArticleCommentRow.UIModel?>
+    @BehaviorRelayProperty(false) var isLoading: Driver<Bool>
+    @PublishRelayProperty var didDeleteComment: Signal<Void>
+    @PublishRelayProperty var didFailToDeleteComment: Signal<Void>
     let id: Int
 
-    init(comment: ArticleComment) {
+    init(args: ArticleCommentRowViewModelArgs) {
+        let comment = args.comment
         id = comment.id
-        uiModel = .just(
-            .init(
-                commentBody: comment.body,
-                commentUpdatedAt: comment.updatedAt.format(with: .monthDayYear),
-                authorName: comment.author.username,
-                authorImage: try? comment.author.image?.asURL()
-            )
-        )
+        slug = args.slug
+
+        getCurrentSessionUseCase.execute()
+            .subscribe(with: self) { owner, user in
+                owner.$uiModel.accept(
+                    .init(
+                        commentBody: comment.body,
+                        commentUpdatedAt: comment.updatedAt.format(with: .monthDayYear),
+                        authorName: comment.author.username,
+                        authorImage: try? comment.author.image?.asURL(),
+                        isAuthor: user?.username == comment.author.username
+                    )
+                )
+            }
+            .disposed(by: disposeBag)
+
+        deleteCommentTrigger
+            .withUnretained(self)
+            .flatMapLatest { $0.0.deleteCommentTriggered(owner: $0.0) }
+            .subscribe()
+            .disposed(by: disposeBag)
     }
 }
 
-extension ArticleCommentRowViewModel: ArticleCommentRowViewModelInput {}
+extension ArticleCommentRowViewModel: ArticleCommentRowViewModelInput {
+
+    func deleteComment() {
+        deleteCommentTrigger.accept(())
+    }
+}
 
 extension ArticleCommentRowViewModel: ArticleCommentRowViewModelOutput {}
 
+// MARK: Private
+
+extension ArticleCommentRowViewModel {
+
+    private func deleteCommentTriggered(owner: ArticleCommentRowViewModel) -> Observable<Void> {
+        owner.$isLoading.accept(true)
+        return deleteArticleCommentUseCase
+            .execute(articleSlug: slug, commentId: "\(id)")
+            .do(
+                onError: { _ in
+                    owner.$isLoading.accept(false)
+                    owner.$didFailToDeleteComment.accept(())
+                },
+                onCompleted: {
+                    owner.$isLoading.accept(false)
+                    owner.$didDeleteComment.accept(())
+                }
+            )
+            .asObservable()
+            .mapToVoid()
+            .catchAndReturn(())
+    }
+}
+
 extension Array where Element == ArticleComment {
 
-    var viewModels: [ArticleCommentRowViewModelProtocol] {
-        map { Resolver.resolve(ArticleCommentRowViewModelProtocol.self, args: $0) }
+    func viewModels(slug: String) -> [ArticleCommentRowViewModelProtocol] {
+        map {
+            Resolver.resolve(
+                ArticleCommentRowViewModelProtocol.self,
+                args: ArticleCommentRowViewModelArgs(slug: slug, comment: $0)
+            )
+        }
     }
 }

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentsViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentsViewModel.swift
@@ -93,9 +93,7 @@ extension ArticleCommentsViewModel {
                     owner.$isCreateCommentEnabled.accept(true)
                     owner.$didFetchArticleComments.accept(())
                     owner.$articleCommentRowViewModels.accept(
-                        $0.map {
-                            owner.articleCommentRowViewModel(from: $0)
-                        }
+                        $0.map { owner.articleCommentRowViewModel(from: $0) }
                     )
                 },
                 onError: { _ in

--- a/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
+++ b/NimbleMediumTests/Sources/Injection/Resolver+Tests.swift
@@ -63,6 +63,8 @@ extension Resolver {
             .implements(ToggleArticleFavoriteStatusUseCaseProtocol.self)
         Resolver.mock.register { UpdateMyArticleUseCaseProtocolMock() }
             .implements(UpdateMyArticleUseCaseProtocol.self)
+        Resolver.mock.register { DeleteArticleCommentUseCaseProtocolMock() }
+            .implements(DeleteArticleCommentUseCaseProtocol.self)
     }
 
     private static func registerViewModels() {

--- a/NimbleMediumTests/Sources/Specs/Presentation/Modules/ArticleComments/FeedCommentRow/ArticleCommentRowViewModelSpec.swift
+++ b/NimbleMediumTests/Sources/Specs/Presentation/Modules/ArticleComments/FeedCommentRow/ArticleCommentRowViewModelSpec.swift
@@ -16,6 +16,9 @@ import RxTest
 
 final class ArticleCommentRowViewModelSpec: QuickSpec {
 
+    @LazyInjected var getCurrentSessionUseCase: GetCurrentSessionUseCaseProtocolMock
+    @LazyInjected var deleteArticleCommentUseCase: DeleteArticleCommentUseCaseProtocolMock
+
     override func spec() {
         var viewModel: ArticleCommentRowViewModelProtocol!
         var scheduler: TestScheduler!
@@ -26,16 +29,20 @@ final class ArticleCommentRowViewModelSpec: QuickSpec {
 
             beforeEach {
                 Resolver.registerMockServices()
+                self.getCurrentSessionUseCase.executeReturnValue = .just(nil)
 
                 let comment = APIArticleCommentsResponse.dummy.comments[0]
                 uiModel = ArticleCommentRow.UIModel(
                     commentBody: comment.body,
                     commentUpdatedAt: comment.updatedAt.format(with: .monthDayYear),
                     authorName: comment.author.username,
-                    authorImage: try? comment.author.image?.asURL()
+                    authorImage: try? comment.author.image?.asURL(),
+                    isAuthor: false
                 )
 
-                viewModel = ArticleCommentRowViewModel(comment: comment)
+                viewModel = ArticleCommentRowViewModel(
+                    args: .init(slug: "", comment: comment)
+                )
                 scheduler = TestScheduler(initialClock: 0)
                 disposeBag = DisposeBag()
             }
@@ -43,9 +50,70 @@ final class ArticleCommentRowViewModelSpec: QuickSpec {
             it("returns output model with correct value") {
                 expect(viewModel.output.uiModel)
                     .events(scheduler: scheduler, disposeBag: disposeBag) == [
-                        .next(0, uiModel),
-                        .completed(0)
+                        .next(0, uiModel)
                     ]
+            }
+
+            describe("its deleteComment() call") {
+
+                context("when DeleteArticleCommentUseCase return success") {
+
+                    beforeEach {
+                        self.deleteArticleCommentUseCase.executeArticleSlugCommentIdReturnValue = .empty(
+                            on: scheduler,
+                            at: 10
+                        )
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.deleteComment()
+                        }
+                    }
+
+                    it("returns output didDeleteComment with signal") {
+                        expect(viewModel.output.didDeleteComment)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .notTo(beEmpty())
+                    }
+
+                    it("returns output isLoading with correct value") {
+                        expect(viewModel.output.isLoading)
+                            .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                                .next(0, false),
+                                .next(5, true),
+                                .next(10, false)
+                            ]
+                    }
+                }
+
+                context("when DeleteArticleCommentUseCase return failure") {
+
+                    beforeEach {
+                        self.deleteArticleCommentUseCase.executeArticleSlugCommentIdReturnValue = .error(
+                            TestError.mock,
+                            on: scheduler,
+                            at: 10
+                        )
+
+                        scheduler.scheduleAt(5) {
+                            viewModel.input.deleteComment()
+                        }
+                    }
+
+                    it("returns output didFailToDeleteComment with signal") {
+                        expect(viewModel.output.didFailToDeleteComment)
+                            .events(scheduler: scheduler, disposeBag: disposeBag)
+                            .notTo(beEmpty())
+                    }
+
+                    it("returns output isLoading with correct value") {
+                        expect(viewModel.output.isLoading)
+                            .events(scheduler: scheduler, disposeBag: disposeBag) == [
+                                .next(0, false),
+                                .next(5, true),
+                                .next(10, false)
+                            ]
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Resolved #108

## What happened

Integrate delete comment

## Insight

- [x] When the users see their own comments on any article via the `Comments History` screen, show the delete comment button for those comments, otherwise hide it.
- [x] When the users press the `Delete` button, call the API to delete the comment from the article and disable the `Delete` button while doing so.
- [x] When there is an error while deleting the comment, show a temporary toast message with text: `Something went wrong. Please try again later.` and just re-enable the `Delete` button.
- [x] If the deletion is successful, reload the list of comments table view with latest data to remove the deleted comment.

## Proof Of Work

https://user-images.githubusercontent.com/17875522/140474022-e6732cd5-87f5-4e99-8ed7-7c49ad5d3fd8.mov



