### PR TITLE
[#238] Chore: Refactor Resolver library scope correctly for ViewModel

### DIFF
--- a/NimbleMedium/Sources/Injection/Resolver+Injection.swift
+++ b/NimbleMedium/Sources/Injection/Resolver+Injection.swift
@@ -156,18 +156,20 @@ extension Resolver: ResolverRegistering {
             ArticleRowViewModel(article: args.get())
         }.implements(ArticleRowViewModelProtocol.self)
         register { CreateArticleViewModel() }.implements(CreateArticleViewModelProtocol.self)
+        register(EditArticleViewModelProtocol.self) { _, args in
+            EditArticleViewModel(slug: args.get())
+        }.scope(.shared)
         register { EditProfileViewModel() }.implements(EditProfileViewModelProtocol.self)
         register { FeedsViewModel() }.implements(FeedsViewModelProtocol.self).scope(.cached)
         register(FeedsTabViewModelProtocol.self) { _, args in
             FeedsTabViewModel(tabType: args.get())
-        }
-        .scope(.unique)
+        }.scope(.unique)
         register { HomeViewModel() }.implements(HomeViewModelProtocol.self).scope(.cached)
-        register { LoginViewModel() }.implements(LoginViewModelProtocol.self).scope(.cached)
-        register { SideMenuActionsViewModel() }.implements(SideMenuActionsViewModelProtocol.self).scope(.cached)
-        register { SideMenuHeaderViewModel() }.implements(SideMenuHeaderViewModelProtocol.self).scope(.cached)
-        register { SideMenuViewModel() }.implements(SideMenuViewModelProtocol.self).scope(.cached)
-        register { SignupViewModel() }.implements(SignupViewModelProtocol.self).scope(.cached)
+        register { LoginViewModel() }.implements(LoginViewModelProtocol.self).scope(.shared)
+        register { SideMenuActionsViewModel() }.implements(SideMenuActionsViewModelProtocol.self).scope(.shared)
+        register { SideMenuHeaderViewModel() }.implements(SideMenuHeaderViewModelProtocol.self).scope(.shared)
+        register { SideMenuViewModel() }.implements(SideMenuViewModelProtocol.self).scope(.shared)
+        register { SignupViewModel() }.implements(SignupViewModelProtocol.self).scope(.shared)
         register { _, args in
             UserProfileViewModel(username: args.get())
         }.implements(UserProfileViewModelProtocol.self)
@@ -177,9 +179,5 @@ extension Resolver: ResolverRegistering {
         register { _, args in
             UserProfileFavouritedArticlesTabViewModel(username: args.get())
         }.implements(UserProfileFavouritedArticlesTabViewModelProtocol.self)
-        register(EditArticleViewModelProtocol.self) { _, args in
-            EditArticleViewModel(slug: args.get())
-        }
-        .scope(.shared)
     }
 }


### PR DESCRIPTION
Resolved #238

## What happened

Current we are using .cached for ViewModel mostly for keeping the same instance when injecting. But we can use .shared to correctly use it in case we need to apply it for parent-child ViewModel relationship cases.

## Insight

Update to use .shared scope for parent/child relationships view models

## Proof Of Work

No visual change, just under the hood optimization and the app works normally. 🛠
