### PR TITLE
[#243] Fix: Username & Email input got uppercase in the first letter in Login & Signup screen

### DIFF
--- a/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Login/LoginView.swift
@@ -71,7 +71,8 @@ struct LoginView: View {
                 AppTextField(
                     placeholder: Localizable.loginTextFieldEmailPlaceholder(),
                     text: $email,
-                    supportEmailKeyboard: true
+                    emailKeyboard: true,
+                    autoCapitalization: false
                 )
                 AppSecureField(
                     placeholder: Localizable.loginTextFieldPasswordPlaceholder(),

--- a/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/Signup/SignupView.swift
@@ -71,12 +71,14 @@ struct SignupView: View {
             VStack(spacing: 15.0) {
                 AppTextField(
                     placeholder: Localizable.signupTextFieldUsernamePlaceholder(),
-                    text: $username
+                    text: $username,
+                    autoCapitalization: false
                 )
                 AppTextField(
                     placeholder: Localizable.signupTextFieldEmailPlaceholder(),
                     text: $email,
-                    supportEmailKeyboard: true
+                    emailKeyboard: true,
+                    autoCapitalization: false
                 )
                 AppSecureField(
                     placeholder: Localizable.signupTextFieldPasswordPlaceholder(),

--- a/NimbleMedium/Sources/Presentation/Views/AppTextField.swift
+++ b/NimbleMedium/Sources/Presentation/Views/AppTextField.swift
@@ -11,7 +11,8 @@ struct AppTextField: View {
 
     private var placeholder: String
     private var text: Binding<String>
-    private var supportEmailKeyboard: Bool
+    private var emailKeyboard: Bool
+    private var autoCapitalization: Bool
 
     var body: some View {
         TextField(placeholder, text: text)
@@ -20,13 +21,15 @@ struct AppTextField: View {
                 RoundedRectangle(cornerRadius: 8.0)
                     .stroke(Color(.lightGray), lineWidth: 1.0)
             )
-            .keyboardType(supportEmailKeyboard ? .emailAddress : .default)
+            .keyboardType(emailKeyboard ? .emailAddress : .default)
             .accentColor(.black)
+            .autocapitalization(autoCapitalization ? .sentences : .none)
     }
 
-    init(placeholder: String, text: Binding<String>, supportEmailKeyboard: Bool = false) {
+    init(placeholder: String, text: Binding<String>, emailKeyboard: Bool = false, autoCapitalization: Bool = true) {
         self.placeholder = placeholder
         self.text = text
-        self.supportEmailKeyboard = supportEmailKeyboard
+        self.emailKeyboard = emailKeyboard
+        self.autoCapitalization = autoCapitalization
     }
 }


### PR DESCRIPTION
Resolved #243 

## What happened

Username & Email input got uppercase in the first letter in Login & Signup screen. Username & Email input should be in lowercase in the first letter in Login & Signup screen.

## Insight

Added a new flag for AppTextField - `autoCapitalization` and disable it for the above input textfields.

## Proof Of Work

https://user-images.githubusercontent.com/70877098/141723680-75cf63c9-4325-43c9-8854-5755d589e46e.MP4



