### PR TITLE
[#244] As a user, I want to see the input label when it's filled in Create & Edit Article screen

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -100,6 +100,8 @@
 		24C9393926D89FA300547800 /* AppTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C9393826D89FA300547800 /* AppTextField.swift */; };
 		24C9393B26D8A1A200547800 /* AppSecureField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C9393A26D8A1A200547800 /* AppSecureField.swift */; };
 		24C9393D26D8A26300547800 /* AppMainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C9393C26D8A26300547800 /* AppMainButton.swift */; };
+		24D6FAFE2743587F00A9522A /* LabeledAppTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D6FAFD2743587F00A9522A /* LabeledAppTextField.swift */; };
+		24D6FB0027435BF900A9522A /* LabeledAppTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D6FAFF27435BF900A9522A /* LabeledAppTextView.swift */; };
 		24D717F8271D3394009B589C /* CreateArticleUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D717F7271D3394009B589C /* CreateArticleUseCaseSpec.swift */; };
 		24D717FA271D3409009B589C /* CreateArticleParameters+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D717F9271D3409009B589C /* CreateArticleParameters+Dummy.swift */; };
 		24E0400C2727FEF400A1985B /* UpdateMyArticleUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E0400B2727FEF400A1985B /* UpdateMyArticleUseCaseSpec.swift */; };
@@ -352,6 +354,8 @@
 		24C9393826D89FA300547800 /* AppTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTextField.swift; sourceTree = "<group>"; };
 		24C9393A26D8A1A200547800 /* AppSecureField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSecureField.swift; sourceTree = "<group>"; };
 		24C9393C26D8A26300547800 /* AppMainButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMainButton.swift; sourceTree = "<group>"; };
+		24D6FAFD2743587F00A9522A /* LabeledAppTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledAppTextField.swift; sourceTree = "<group>"; };
+		24D6FAFF27435BF900A9522A /* LabeledAppTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LabeledAppTextView.swift; sourceTree = "<group>"; };
 		24D717F7271D3394009B589C /* CreateArticleUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateArticleUseCaseSpec.swift; sourceTree = "<group>"; };
 		24D717F9271D3409009B589C /* CreateArticleParameters+Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreateArticleParameters+Dummy.swift"; sourceTree = "<group>"; };
 		24E0400B2727FEF400A1985B /* UpdateMyArticleUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateMyArticleUseCaseSpec.swift; sourceTree = "<group>"; };
@@ -1246,11 +1250,13 @@
 				24C9393A26D8A1A200547800 /* AppSecureField.swift */,
 				24C9393826D89FA300547800 /* AppTextField.swift */,
 				244E0FF62715316900C01139 /* AppTextView.swift */,
-				24204C9D26D5289900534314 /* Background.swift */,
 				2D17E4EE26F07738001D3F90 /* AuthorView.swift */,
 				2D469D3E2704430A00B36AD6 /* AvatarView.swift */,
+				24204C9D26D5289900534314 /* Background.swift */,
 				2DAF7F1627141C4000C001B8 /* FollowButton.swift */,
 				2D3829F5272B9C6F00047822 /* FavouriteButton.swift */,
+				24D6FAFD2743587F00A9522A /* LabeledAppTextField.swift */,
+				24D6FAFF27435BF900A9522A /* LabeledAppTextView.swift */,
 				2D284134271EAB23005B62D6 /* PagerTabItemTitle.swift */,
 			);
 			path = Views;
@@ -2369,6 +2375,7 @@
 				2D882EDA26F1CBA200DB6560 /* ArticleCommentRepositoryProtocol.swift in Sources */,
 				24C9393D26D8A26300547800 /* AppMainButton.swift in Sources */,
 				24FB783D26FC3A80007534BE /* UserProfileView+UIModel.swift in Sources */,
+				24D6FAFE2743587F00A9522A /* LabeledAppTextField.swift in Sources */,
 				2D73312926F0EFD20052DCC7 /* APIArticleResponse.swift in Sources */,
 				241B99DE26DF34720041207F /* SignupUseCase.swift in Sources */,
 				24A2C701271D1FF7002E4A5A /* Encodable+Dictionary.swift in Sources */,
@@ -2388,6 +2395,7 @@
 				2497356126D34F3200177A7C /* SideMenuActionsView.swift in Sources */,
 				2459B32826D751E300ABCE61 /* LoginUseCase.swift in Sources */,
 				2D29A70F26F44EBC001EA24F /* ArticleRowViewModel.swift in Sources */,
+				24D6FB0027435BF900A9522A /* LabeledAppTextView.swift in Sources */,
 				2424B22C26D4A22B00CF07B5 /* LoginView.swift in Sources */,
 				2D031D5526EB1093009A5158 /* View+Bind.swift in Sources */,
 				2D469D3F2704430A00B36AD6 /* AvatarView.swift in Sources */,

--- a/NimbleMedium/Resources/en.lproj/Localizable.strings
+++ b/NimbleMedium/Resources/en.lproj/Localizable.strings
@@ -19,17 +19,25 @@
 
 "createArticle.title.text" = "Create Article";
 "createArticle.textFieldDescription.placeholder" = "What's this article about";
+"createArticle.textFieldDescription.title" = "Description";
 "createArticle.textFieldTagsList.placeholder" = "Enter tags (separated by comma)";
+"createArticle.textFieldTagsList.title" = "Tags";
 "createArticle.textFieldTitle.placeholder" = "Article Title";
+"createArticle.textFieldTitle.title" = "Title";
 "createArticle.textViewBody.placeholder" = "Write your article";
+"createArticle.textViewBody.title" = "Body";
 
 "default.username.value" = "Current User";
 
 "editArticle.title.text" = "Update Article";
 "editArticle.textFieldDescription.placeholder" = "What's this article about";
+"editArticle.textFieldDescription.title" = "Description";
 "editArticle.textFieldTagsList.placeholder" = "Enter tags (separated by comma)";
+"editArticle.textFieldTagsList.title" = "Tags";
 "editArticle.textFieldTitle.placeholder" = "Article Title";
+"editArticle.textFieldTitle.title" = "Title";
 "editArticle.textViewBody.placeholder" = "Write your article";
+"editArticle.textViewBody.title" = "Body";
 
 "editProfile.textFieldAvatarURL.placeholder" = "Url of the new profile picture";
 "editProfile.textFieldEmail.placeholder" = "New email";

--- a/NimbleMedium/Sources/Presentation/Modules/CreateArticle/CreateArticleView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/CreateArticle/CreateArticleView.swift
@@ -60,25 +60,36 @@ struct CreateArticleView: View {
         }
     }
 
+    // swiftlint:disable closure_body_length
     var contentView: some View {
         ScrollView {
             VStack(spacing: 15.0) {
-                AppTextField(placeholder: Localizable.createArticleTextFieldTitlePlaceholder(), text: $title)
-                    .font(.system(size: 20))
-                AppTextField(
+                LabeledAppTextField(
+                    title: Localizable.createArticleTextFieldTitleTitle(),
+                    placeholder: Localizable.createArticleTextFieldTitlePlaceholder(),
+                    text: $title
+                ).font(.system(size: 20))
+                LabeledAppTextField(
+                    title: Localizable.createArticleTextFieldDescriptionTitle(),
                     placeholder: Localizable.createArticleTextFieldDescriptionPlaceholder(),
                     text: $description
                 )
-                AppTextView(placeholder: Localizable.createArticleTextViewBodyPlaceholder(), text: $articleBody)
-                    .frame(height: 200.0, alignment: .leading)
-                AppTextField(placeholder: Localizable.createArticleTextFieldTagsListPlaceholder(), text: $tagsList)
+                LabeledAppTextView(
+                    title: Localizable.createArticleTextViewBodyTitle(),
+                    placeholder: Localizable.createArticleTextViewBodyPlaceholder(),
+                    text: $articleBody
+                ).frame(height: 230.0, alignment: .leading)
+                LabeledAppTextField(
+                    title: Localizable.createArticleTextFieldTagsListTitle(),
+                    placeholder: Localizable.createArticleTextFieldTagsListPlaceholder(),
+                    text: $tagsList
+                )
                 AppMainButton(title: Localizable.actionPublishText()) {
                     hideKeyboard()
                     viewModel.input.didTapPublishButton(
                         title: title, description: description, body: articleBody, tagsList: tagsList
                     )
-                }
-                .disabled(title.isEmpty && description.isEmpty && articleBody.isEmpty && tagsList.isEmpty)
+                }.disabled(title.isEmpty && description.isEmpty && articleBody.isEmpty && tagsList.isEmpty)
             }
             .padding()
         }

--- a/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/EditArticle/EditArticleView.swift
@@ -83,18 +83,30 @@ struct EditArticleView: View {
         }
     }
 
+    // swiftlint:disable closure_body_length
     var form: some View {
         ScrollView {
             VStack(spacing: 15.0) {
-                AppTextField(placeholder: Localizable.editArticleTextFieldTitlePlaceholder(), text: $title)
-                    .font(.system(size: 20))
-                AppTextField(
+                LabeledAppTextField(
+                    title: Localizable.editArticleTextFieldTitleTitle(),
+                    placeholder: Localizable.editArticleTextFieldTitlePlaceholder(),
+                    text: $title
+                ).font(.system(size: 20))
+                LabeledAppTextField(
+                    title: Localizable.editArticleTextFieldDescriptionTitle(),
                     placeholder: Localizable.editArticleTextFieldDescriptionPlaceholder(),
                     text: $description
                 )
-                AppTextView(placeholder: Localizable.editArticleTextViewBodyPlaceholder(), text: $articleBody)
-                    .frame(height: 200.0, alignment: .leading)
-                AppTextField(placeholder: Localizable.editArticleTextFieldTagsListPlaceholder(), text: $tagsList)
+                LabeledAppTextView(
+                    title: Localizable.editArticleTextViewBodyTitle(),
+                    placeholder: Localizable.editArticleTextViewBodyPlaceholder(),
+                    text: $articleBody
+                ).frame(height: 230.0, alignment: .leading)
+                LabeledAppTextField(
+                    title: Localizable.editArticleTextFieldTagsListTitle(),
+                    placeholder: Localizable.editArticleTextFieldTagsListPlaceholder(),
+                    text: $tagsList
+                )
                 AppMainButton(title: Localizable.actionUpdateText()) {
                     viewModel.input.didTapUpdateButton(
                         title: title,
@@ -102,10 +114,8 @@ struct EditArticleView: View {
                         body: articleBody,
                         tagsList: tagsList
                     )
-                }
-                .disabled(title.isEmpty && description.isEmpty && articleBody.isEmpty && tagsList.isEmpty)
-            }
-            .padding()
+                }.disabled(title.isEmpty && description.isEmpty && articleBody.isEmpty && tagsList.isEmpty)
+            }.padding()
         }
     }
 }

--- a/NimbleMedium/Sources/Presentation/Views/LabeledAppTextField.swift
+++ b/NimbleMedium/Sources/Presentation/Views/LabeledAppTextField.swift
@@ -1,0 +1,37 @@
+//
+//  LabeledAppTextField.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 16/11/2021.
+//
+
+import SwiftUI
+
+struct LabeledAppTextField: View {
+
+    private var title: String
+    private var placeholder: String
+    private var text: Binding<String>
+    private var emailKeyboard: Bool
+    private var autoCapitalization: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4.0) {
+            Text(title).foregroundColor(.black)
+            AppTextField(
+                placeholder: placeholder,
+                text: text,
+                emailKeyboard: emailKeyboard,
+                autoCapitalization: autoCapitalization
+            )
+        }
+    }
+
+    init(title: String, placeholder: String, text: Binding<String>, emailKeyboard: Bool = false, autoCapitalization: Bool = true) {
+        self.title = title
+        self.placeholder = placeholder
+        self.text = text
+        self.emailKeyboard = emailKeyboard
+        self.autoCapitalization = autoCapitalization
+    }
+}

--- a/NimbleMedium/Sources/Presentation/Views/LabeledAppTextView.swift
+++ b/NimbleMedium/Sources/Presentation/Views/LabeledAppTextView.swift
@@ -1,0 +1,30 @@
+//
+//  LabeledAppTextView.swift
+//  NimbleMedium
+//
+//  Created by Minh Pham on 16/11/2021.
+//
+
+import SwiftUI
+
+struct LabeledAppTextView: View {
+
+    private var title: String
+    private var configuration: ((AppTextView.UIViewType) -> Void)?
+    private var placeholder: String
+    private var text: Binding<String>
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4.0) {
+            Text(title).foregroundColor(.black)
+            AppTextView(placeholder: placeholder, text: text, configuration: configuration)
+        }
+    }
+
+    init(title: String, placeholder: String, text: Binding<String>, configuration: ((AppTextView.UIViewType) -> Void)? = nil) {
+        self.title = title
+        self.placeholder = placeholder
+        self.text = text
+        self.configuration = configuration
+    }
+}


### PR DESCRIPTION
Resolved #244

## What happened

As a user, I want to see the input label when it's filled so that I can know which label is in Create & Edit Article screen.

## Insight

- Create `LabeledAppTextField` and `LabeledAppTextView` that have a label above the input field for letting user knows which field is for.
- Apply the new fields to Create and Edit Article screens.

## Proof Of Work

<img src="https://user-images.githubusercontent.com/70877098/141891869-63fae4b4-f9a8-48e7-a4d3-f6f484df8bbb.jpeg" width="300">
