### PR TITLE
[#250] Fix: Comment is not cleared after sending successfully and keyboard got dismissed when sending

### DIFF
--- a/NimbleMedium.xcodeproj/project.pbxproj
+++ b/NimbleMedium.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		2D892BA726E8698700579856 /* NetworkAPIProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D892BA626E8698700579856 /* NetworkAPIProtocolMock.swift */; };
 		2D892BA926E89A6100579856 /* APIArticlesResponse+Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D892BA826E89A6100579856 /* APIArticlesResponse+Dummy.swift */; };
 		2D9032D026F04D96005CA3F5 /* ArticleDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9032CF26F04D96005CA3F5 /* ArticleDetailView.swift */; };
+		2D93CC6327460A70005C30A0 /* Introspect in Frameworks */ = {isa = PBXBuildFile; productRef = 2D93CC6227460A70005C30A0 /* Introspect */; };
 		2D979C30270302650084A3F8 /* GetCreatedArticlesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D979C2F270302650084A3F8 /* GetCreatedArticlesUseCase.swift */; };
 		2D979C322703034C0084A3F8 /* GetCreatedArticlesUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D979C312703034C0084A3F8 /* GetCreatedArticlesUseCaseSpec.swift */; };
 		2DA4ABBF26CF90D000CF7D68 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA4ABBE26CF90D000CF7D68 /* AppEnvironment.swift */; };
@@ -521,6 +522,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2459B35B26D7A7C500ABCE61 /* ToastUI in Frameworks */,
+				2D93CC6327460A70005C30A0 /* Introspect in Frameworks */,
 				2DEF1F8A26E5FD0C00EB93CC /* SDWebImageSwiftUI in Frameworks */,
 				7DB2A8DC1F8863DD01F7D438 /* Pods_NimbleMedium.framework in Frameworks */,
 				24F3D7B726DCEA0300DE2420 /* KeychainAccess in Frameworks */,
@@ -1922,6 +1924,7 @@
 				248E13AB26F054FD00439BCC /* Resolver */,
 				2D5C62B12701A69F00398C96 /* Refresh */,
 				2D531863270EA3D300F8FADD /* PagerTabStripView */,
+				2D93CC6227460A70005C30A0 /* Introspect */,
 			);
 			productName = NimbleMedium;
 			productReference = 2DB2674A26BBEC4300FF05BB /* Nimble Medium - Staging.app */;
@@ -2009,6 +2012,7 @@
 				248E13AA26F054FD00439BCC /* XCRemoteSwiftPackageReference "Resolver" */,
 				2D5C62B02701A69F00398C96 /* XCRemoteSwiftPackageReference "Refresh" */,
 				2D531862270EA3D300F8FADD /* XCRemoteSwiftPackageReference "PagerTabStripView" */,
+				2D93CC6127460A70005C30A0 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 			);
 			productRefGroup = 2DB2674B26BBEC4300FF05BB /* Products */;
 			projectDirPath = "";
@@ -3221,6 +3225,14 @@
 				minimumVersion = 1.2.1;
 			};
 		};
+		2D93CC6127460A70005C30A0 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		2DEF1F8826E5FD0C00EB93CC /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SDWebImage/SDWebImageSwiftUI";
@@ -3261,6 +3273,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2D6EFE1926E9EB8C006B9939 /* XCRemoteSwiftPackageReference "DefaultCodable" */;
 			productName = DefaultCodable;
+		};
+		2D93CC6227460A70005C30A0 /* Introspect */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D93CC6127460A70005C30A0 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
+			productName = Introspect;
 		};
 		2DEF1F8926E5FD0C00EB93CC /* SDWebImageSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/NimbleMedium.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NimbleMedium.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -65,6 +65,15 @@
         }
       },
       {
+        "package": "Introspect",
+        "repositoryURL": "https://github.com/siteline/SwiftUI-Introspect",
+        "state": {
+          "branch": "master",
+          "revision": "72a509c93166540c0adf8323fd2652daade7f9f6",
+          "version": null
+        }
+      },
+      {
         "package": "ToastUI",
         "repositoryURL": "https://github.com/quanshousio/ToastUI",
         "state": {

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentsView.swift
@@ -22,6 +22,7 @@ struct ArticleCommentsView: View {
     @State private var commentContent: String = ""
     @State private var isCreateCommentEnabled = false
     @State private var isAuthenticated = false
+    @State private var shouldCommentContentInputEndEditing = false
 
     private var isPostCommentButtonEnabled: Bool {
         isCreateCommentEnabled && !commentContent.isEmpty
@@ -33,6 +34,13 @@ struct ArticleCommentsView: View {
             if isAuthenticated {
                 Spacer()
                 commentInput
+            }
+        }
+        .onTapGesture {
+            shouldCommentContentInputEndEditing = true
+            hideKeyboard()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                shouldCommentContentInputEndEditing = false
             }
         }
         .toast(isPresented: $isErrorToastPresented, dismissAfter: 3.0) {
@@ -52,6 +60,9 @@ struct ArticleCommentsView: View {
         }
         .onReceive(viewModel.output.didFetchArticleComments) {
             isFetchingArticleComments = false
+        }
+        .onReceive(viewModel.output.didCreateArticleComment) {
+            commentContent = ""
         }
         .onReceive(viewModel.output.articleCommentRowViewModels) {
             articleCommentRowViewModels = $0
@@ -91,6 +102,7 @@ struct ArticleCommentsView: View {
                 placeholder: Localizable.feedCommentsCommentTextViewPlaceholder(),
                 text: $commentContent
             )
+            .shouldEndEditing(shouldCommentContentInputEndEditing)
             .disabled(!isCreateCommentEnabled)
             Button {
                 viewModel.input.createArticleComment(content: commentContent)

--- a/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentsView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleComments/ArticleCommentsView.swift
@@ -114,6 +114,7 @@ struct ArticleCommentsView: View {
         }
         .frame(height: 50)
         .padding(.horizontal, 20.0)
+        .padding(.bottom, 10.0)
     }
 
     init(id: String) {

--- a/NimbleMedium/Sources/Presentation/Views/AppTextView.swift
+++ b/NimbleMedium/Sources/Presentation/Views/AppTextView.swift
@@ -21,12 +21,14 @@ struct AppTextView: View {
                 Text(placeholder)
                     .foregroundColor(Color(.label))
                     .padding(.top, 10.0)
+                    .padding(.leading, 5.0)
             }
             TextEditor(text: $text)
                 .opacity(text.isEmpty ? 0.7 : 1.0)
                 .introspectTextView {
                     $0.delegate = delegateResponder
                 }
+                .accentColor(.black)
         }
         .padding([.leading, .trailing], 8.0)
         .overlay(

--- a/NimbleMedium/Sources/Presentation/Views/AppTextView.swift
+++ b/NimbleMedium/Sources/Presentation/Views/AppTextView.swift
@@ -5,79 +5,71 @@
 //  Created by Minh Pham on 12/10/2021.
 //
 
+import Introspect
 import SwiftUI
 
-// swiftlint:disable type_contents_order
-struct AppTextView: UIViewRepresentable {
+struct AppTextView: View {
 
-    typealias UIViewType = UITextView
+    @Binding private var text: String
 
-    private var configuration: ((UIViewType) -> Void)?
-    private var placeholder: String
-    private var text: Binding<String>
+    private let placeholder: String
+    private var delegateResponder: DelegateResponder
 
-    private let placeholderTextColor = UIColor.lightGray.withAlphaComponent(0.7)
-
-    init(placeholder: String, text: Binding<String>, configuration: ((UIViewType) -> Void)? = nil) {
-        self.placeholder = placeholder
-        self.text = text
-        self.configuration = configuration
-    }
-
-    func makeUIView(context: UIViewRepresentableContext<Self>) -> UIViewType {
-        let textView = UITextView()
-        textView.autocapitalizationType = .sentences
-        textView.delegate = context.coordinator
-        textView.font = .preferredFont(forTextStyle: UIFont.TextStyle.body)
-        textView.isSelectable = true
-        textView.layer.borderColor = UIColor.lightGray.cgColor
-        textView.layer.borderWidth = 1.0
-        textView.layer.cornerRadius = 8.0
-        textView.text = placeholder
-        textView.textColor = placeholderTextColor
-        textView.textContainerInset = UIEdgeInsets(top: 8.0, left: 10.0, bottom: 8.0, right: 10.0)
-        textView.tintColor = .black
-        return textView
-    }
-
-    func updateUIView(_ uiView: UIViewType, context: UIViewRepresentableContext<Self>) {
-        if !text.wrappedValue.isEmpty {
-            uiView.text = text.wrappedValue
-            uiView.textColor = .black
+    var body: some View {
+        ZStack(alignment: Alignment(horizontal: .leading, vertical: .top)) {
+            if text.isEmpty {
+                Text(placeholder)
+                    .foregroundColor(Color(.label))
+                    .padding(.top, 10.0)
+            }
+            TextEditor(text: $text)
+                .opacity(text.isEmpty ? 0.7 : 1.0)
+                .introspectTextView {
+                    $0.delegate = delegateResponder
+                }
         }
-        configuration?(uiView)
+        .padding([.leading, .trailing], 8.0)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8.0)
+                .stroke(Color(.lightGray), lineWidth: 1.0)
+        )
     }
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(text, placeholder: placeholder, placeholderTextColor: placeholderTextColor)
+    init(placeholder: String, text: Binding<String>) {
+        self.placeholder = placeholder
+        _text = text
+        delegateResponder = .init(text: text, shouldEndEditing: true)
     }
 
-    class Coordinator: NSObject, UITextViewDelegate {
+    func shouldEndEditing(_ bool: Bool) -> Self {
+        var view = self
+        view.delegateResponder = .init(
+            text: view.$text,
+            shouldEndEditing: bool
+        )
 
-        var text: Binding<String>
-        var placeholder: String
-        var placeholderTextColor: UIColor
+        return view
+    }
+}
 
-        init(_ text: Binding<String>, placeholder: String, placeholderTextColor: UIColor) {
+extension AppTextView {
+
+    class DelegateResponder: NSObject, UITextViewDelegate {
+
+        let text: Binding<String>
+        let shouldEndEditing: Bool
+
+        init(text: Binding<String>, shouldEndEditing: Bool) {
             self.text = text
-            self.placeholder = placeholder
-            self.placeholderTextColor = placeholderTextColor
+            self.shouldEndEditing = shouldEndEditing
         }
 
         func textViewDidChange(_ textView: UITextView) {
             text.wrappedValue = textView.text
         }
 
-        func textViewDidEndEditing(_ textView: UITextView) {
-            guard textView.text.isEmpty else { return }
-            textView.text = placeholder
-            textView.textColor = placeholderTextColor
-        }
-
-        func textViewDidBeginEditing(_ textView: UITextView) {
-            guard textView.textColor == placeholderTextColor else { return }
-            textView.text = nil
-            textView.textColor = .black
+        func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
+            shouldEndEditing
         }
     }
 }

--- a/NimbleMedium/Sources/Presentation/Views/LabeledAppTextView.swift
+++ b/NimbleMedium/Sources/Presentation/Views/LabeledAppTextView.swift
@@ -10,21 +10,19 @@ import SwiftUI
 struct LabeledAppTextView: View {
 
     private var title: String
-    private var configuration: ((AppTextView.UIViewType) -> Void)?
     private var placeholder: String
     private var text: Binding<String>
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4.0) {
             Text(title).foregroundColor(.black)
-            AppTextView(placeholder: placeholder, text: text, configuration: configuration)
+            AppTextView(placeholder: placeholder, text: text)
         }
     }
 
-    init(title: String, placeholder: String, text: Binding<String>, configuration: ((AppTextView.UIViewType) -> Void)? = nil) {
+    init(title: String, placeholder: String, text: Binding<String>) {
         self.title = title
         self.placeholder = placeholder
         self.text = text
-        self.configuration = configuration
     }
 }


### PR DESCRIPTION
Resolved #250 

## What happened

- Refactor `AppTextView`
- Clear comment input when posting successfully
- Tap outside to dismiss keyboard when comment input is focused

## Insight

n/a

## Proof Of Work



https://user-images.githubusercontent.com/17875522/142378614-aa1fac04-465f-4c8b-a6de-61869b180e72.mov







