### PR TITLE
[#264] Fix: Align article contents to the left for small contents in Article screen

### DIFF
--- a/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/ArticleDetail/ArticleDetailView.swift
@@ -156,6 +156,7 @@ struct ArticleDetailView: View {
             .background(Color(R.color.dark.name))
 
             Text(uiModel.articleBody)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 8.0)
 
             comments


### PR DESCRIPTION
Resolved #264 

## What happened

Fix article content align incorrectly

## Insight

n/a

## Proof Of Work

![Screen Shot 2021-11-25 at 11 31 14](https://user-images.githubusercontent.com/17875522/143379992-1a3d4d1b-b483-4a17-be2b-631ee6ed682f.png)

