### PR TITLE
[#272] Fix: Missing "No Article" text when no article for Favorite Article section in My Profile screen

### DIFF
--- a/NimbleMedium/Sources/Presentation/Modules/UserProfile/CreatedArticlesTab/UserProfileCreatedArticlesTab.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/UserProfile/CreatedArticlesTab/UserProfileCreatedArticlesTab.swift
@@ -21,7 +21,11 @@ struct UserProfileCreatedArticlesTab: View {
     var body: some View {
         Group {
             if isCreatedArticlesFetched {
-                UserProfileArticleList(viewModels: articleRowViewModels)
+                if articleRowViewModels.isEmpty {
+                    Text(Localizable.feedsNoArticle())
+                } else {
+                    UserProfileArticleList(viewModels: articleRowViewModels)
+                }
             } else {
                 if isFetchCreatedArticlesFailed {
                     Text(Localizable.feedsNoArticle())

--- a/NimbleMedium/Sources/Presentation/Modules/UserProfile/FavortiedArticlesTab/UserProfileFavoritedArticlesTab.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/UserProfile/FavortiedArticlesTab/UserProfileFavoritedArticlesTab.swift
@@ -21,7 +21,11 @@ struct UserProfileFavoritedArticlesTab: View {
     var body: some View {
         Group {
             if isFavoritedArticlesFetched {
-                UserProfileArticleList(viewModels: articleRowViewModels)
+                if articleRowViewModels.isEmpty {
+                    Text(Localizable.feedsNoArticle())
+                } else {
+                    UserProfileArticleList(viewModels: articleRowViewModels)
+                }
             } else {
                 if isFetchFavoritedArticlesFailed {
                     Text(Localizable.feedsNoArticle())


### PR DESCRIPTION
Resolved #272

## What happened

Fix: No Article doesn't show up in Favorite Article tab

## Insight

`No article` doesn't show up cause the API returns an empty list not an error

## Proof Of Work



https://user-images.githubusercontent.com/17875522/144165762-3352cd37-f9a2-4ddc-9c56-ec962b398efb.mov




