### PR TITLE
[#276] Fix: Missing Create Articles and Favorite Articles sections in other Author Profile screen

### DIFF
--- a/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileView.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileView.swift
@@ -49,7 +49,9 @@ struct UserProfileView: View {
                 )
             )
         }
-        .navigationTitle(username != nil ? Localizable.userProfileOtherTitle() : Localizable.userProfileCurrentTitle())
+        .navigationTitle(
+            isCurrentUserProfile ? Localizable.userProfileCurrentTitle() : Localizable.userProfileOtherTitle()
+        )
         .modifier(NavigationBarPrimaryStyle())
         .onAppear { viewModel.input.getUserProfile() }
         .toast(isPresented: $errorToast, dismissAfter: 3.0) {

--- a/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileViewModel.swift
+++ b/NimbleMedium/Sources/Presentation/Modules/UserProfile/UserProfileViewModel.swift
@@ -142,6 +142,18 @@ extension UserProfileViewModel {
             .do(
                 onSuccess: {
                     owner.$userProfileUIModel.accept(owner.generateUIModel(fromProfile: $0))
+                    owner.$createdArticlesViewModel.accept(
+                        Resolver.resolve(
+                            UserProfileCreatedArticlesTabViewModelProtocol.self,
+                            args: username
+                        )
+                    )
+                    owner.$favoritedArticlesViewModel.accept(
+                        Resolver.resolve(
+                            UserProfileFavoritedArticlesTabViewModelProtocol.self,
+                            args: username
+                        )
+                    )
                 },
                 onError: { error in
                     owner.$errorMessage.accept(error.detail)


### PR DESCRIPTION
Resolved #276 

## What happened

The Create Articles and Favorite Articles sections don't show up in other Author Profile screen. These sections should show up with data in other Author Profile screen like My Profile screen.

## Insight

- There is no code for loading data for these sections in other Author Profile screen. Add missing code to load the data accordingly.

## Proof Of Work

- Guest user case:

https://user-images.githubusercontent.com/70877098/144191379-8e5684af-0b71-4d90-beb1-85ca4bde65c1.MP4

- Authenticated user case:

https://user-images.githubusercontent.com/70877098/144191420-80375500-a6b5-4749-a17c-07c88cc6033a.MP4



